### PR TITLE
feat: Gradio interactive quiz app (closes #2)

### DIFF
--- a/app.py
+++ b/app.py
@@ -3,7 +3,7 @@
 Two modes
 ---------
 Practice  — answer each question and get immediate feedback + rationale before moving on.
-Exam      — answer all questions within a time limit; full debrief with explanations at the end.
+Exam      — navigate freely between questions, submit when ready (or when time runs out).
 
 Launch with:
     uv run --group app python app.py
@@ -54,10 +54,10 @@ def _initial_state() -> dict:
         "quiz_name": "",  # stored for restart
         "idx": 0,
         "answers": [],  # 1-based chosen index per question, None = unanswered
-        "submitted": False,  # whether current question was submitted (practice only)
+        "submitted": False,  # True after on_submit in practice (locks radio)
         "mode": "practice",  # "practice" | "exam"
-        "start_time": None,  # time.time() when exam started, None when inactive
-        "limit_seconds": 0,  # exam time limit in seconds
+        "start_time": None,  # time.time() when exam started; None = inactive
+        "limit_seconds": 0,
     }
 
 
@@ -87,7 +87,7 @@ def _score(state: dict) -> int:
 
 
 def _record_answer(state: dict, choice: str | None) -> None:
-    """Parse the radio choice string and store the 1-based index in state."""
+    """Store the 1-based answer index for the current question."""
     if choice is None or not state.get("quiz"):
         return
     letter = choice.split(")")[0].strip() if ")" in choice else choice
@@ -95,6 +95,17 @@ def _record_answer(state: dict, choice: str | None) -> None:
     idx = state["idx"]
     if idx < len(state["answers"]):
         state["answers"][idx] = chosen_idx
+
+
+def _stored_choice(state: dict) -> str | None:
+    """Return the radio choice string for the already-recorded answer, or None."""
+    idx = state["idx"]
+    answers = state.get("answers", [])
+    if idx >= len(answers) or answers[idx] is None:
+        return None
+    ans = answers[idx]  # 1-based
+    choices = _choices_for(state)
+    return choices[ans - 1] if 1 <= ans <= len(choices) else None
 
 
 # ---------------------------------------------------------------------------
@@ -138,7 +149,7 @@ def _question_html(state: dict, with_feedback: bool = False) -> str:
     return out
 
 
-def _choices(state: dict) -> list[str]:
+def _choices_for(state: dict) -> list[str]:
     q = _current_q(state)
     if not q:
         return []
@@ -187,27 +198,28 @@ def _debrief_html(state: dict) -> str:
 
 
 def _fmt_time(seconds: float) -> str:
-    seconds = max(0, int(seconds))
-    return f"⏱ {seconds // 60:02d}:{seconds % 60:02d}"
+    s = max(0, int(seconds))
+    return f"⏱ {s // 60:02d}:{s % 60:02d}"
 
 
 # ---------------------------------------------------------------------------
-# Event handlers
+# Output helpers
 #
-# Full output contract (10 values):
+# Full contract — 11 outputs (_ALL):
 #   state, question_html, radio,
-#   btn_submit, btn_next, btn_finish, btn_summary,
+#   btn_submit, btn_prev, btn_next, btn_finish, btn_summary,
 #   summary_html, timer_display, btn_restart
 # ---------------------------------------------------------------------------
 
 
 def _blank() -> tuple:
-    """Return a fully-reset 10-output tuple (no quiz loaded)."""
+    """Fully-reset 11-output tuple for when no quiz is loaded."""
     return (
         _initial_state(),
         _no_quiz_html(),
         gr.update(choices=[], value=None),
         gr.update(visible=False),  # btn_submit
+        gr.update(visible=False),  # btn_prev
         gr.update(visible=False),  # btn_next
         gr.update(visible=False),  # btn_finish
         gr.update(visible=False),  # btn_summary
@@ -217,8 +229,55 @@ def _blank() -> tuple:
     )
 
 
+def _exam_nav(state: dict) -> tuple:
+    """Return the 11-output tuple for a normal exam question view."""
+    idx = state["idx"]
+    total = _total(state)
+    at_first = idx == 0
+    at_last = idx >= total - 1
+    return (
+        state,
+        _question_html(state),
+        gr.update(
+            choices=_choices_for(state),
+            value=_stored_choice(state),  # restore previously selected answer
+            interactive=True,
+        ),
+        gr.update(visible=False),  # btn_submit
+        gr.update(visible=not at_first),  # btn_prev
+        gr.update(visible=not at_last),  # btn_next
+        gr.update(visible=True),  # btn_finish (always)
+        gr.update(visible=False),  # btn_summary
+        gr.update(value="", visible=False),  # summary_html
+        gr.update(),  # timer_display: keep as-is
+        gr.update(visible=False),  # btn_restart
+    )
+
+
+def _debrief_outputs(state: dict) -> tuple:
+    """Return the 11-output tuple showing the debrief panel."""
+    state = {**state, "start_time": None}  # stop timer
+    return (
+        state,
+        gr.update(value="", visible=False),
+        gr.update(choices=[], visible=False),
+        gr.update(visible=False),  # btn_submit
+        gr.update(visible=False),  # btn_prev
+        gr.update(visible=False),  # btn_next
+        gr.update(visible=False),  # btn_finish
+        gr.update(visible=False),  # btn_summary
+        gr.update(value=_debrief_html(state), visible=True),
+        gr.update(value="", visible=False),  # hide timer
+        gr.update(visible=True),  # btn_restart
+    )
+
+
+# ---------------------------------------------------------------------------
+# Event handlers
+# ---------------------------------------------------------------------------
+
+
 def on_load_quiz(name: str, mode: str) -> tuple:
-    """Load a quiz and initialise the correct mode layout."""
     if not name:
         return _blank()
     quiz = _load_quiz(name)
@@ -238,48 +297,56 @@ def on_load_quiz(name: str, mode: str) -> tuple:
     if is_exam:
         state["start_time"] = time.time()
         state["limit_seconds"] = limit_seconds
+        # Exam: show first question with nav buttons + timer
+        total = _total(state)
+        return (
+            state,
+            _question_html(state),
+            gr.update(choices=_choices_for(state), value=None, interactive=True),
+            gr.update(visible=False),  # btn_submit
+            gr.update(visible=False),  # btn_prev (at Q1)
+            gr.update(visible=total > 1),  # btn_next
+            gr.update(visible=True),  # btn_finish
+            gr.update(visible=False),  # btn_summary
+            gr.update(value="", visible=False),  # summary_html
+            gr.update(value=_fmt_time(limit_seconds), visible=True),
+            gr.update(visible=False),  # btn_restart
+        )
+    else:
+        # Practice: show first question with Submit
+        return (
+            state,
+            _question_html(state),
+            gr.update(choices=_choices_for(state), value=None, interactive=True),
+            gr.update(visible=True),  # btn_submit
+            gr.update(visible=False),  # btn_prev
+            gr.update(visible=False),  # btn_next (appears after submit)
+            gr.update(visible=False),  # btn_finish
+            gr.update(visible=False),  # btn_summary
+            gr.update(value="", visible=False),  # summary_html
+            gr.update(value="", visible=False),  # no timer
+            gr.update(visible=False),  # btn_restart
+        )
 
-    return (
-        state,
-        _question_html(state),
-        gr.update(choices=_choices(state), value=None, interactive=True),
-        gr.update(visible=not is_exam),  # btn_submit: practice only
-        gr.update(visible=is_exam),  # btn_next: exam immediately; practice after submit
-        gr.update(visible=is_exam),  # btn_finish: exam only
-        gr.update(visible=False),  # btn_summary
-        gr.update(value="", visible=False),  # summary_html
-        gr.update(value=_fmt_time(limit_seconds), visible=is_exam),  # timer: show start time
-        gr.update(visible=False),  # btn_restart
-    )
 
-
-def on_timer_tick(state: dict) -> tuple:
-    """Update the countdown display every second (exam mode only).
-
-    Returns (timer_display update, state).  State is returned so the
-    timer can mark itself inactive when time runs out.
-    """
-    if state.get("mode") != "exam" or state.get("start_time") is None:
-        return gr.update(), state
-
-    elapsed = time.time() - state["start_time"]
-    remaining = state["limit_seconds"] - elapsed
-
-    if remaining <= 0:
-        state = {**state, "start_time": None}  # deactivate
-        return gr.update(value="⏱ 00:00 — Time's up!", visible=True), state
-
-    return gr.update(value=_fmt_time(remaining), visible=True), state
+def on_radio_change(state: dict, choice: str | None) -> dict:
+    """Exam mode only: auto-save answer on radio selection (no server round-trip needed
+    for practice — Submit handles that)."""
+    if state.get("mode") == "exam":
+        _record_answer(state, choice)
+    return state
 
 
 def on_submit(state: dict, choice: str | None) -> tuple:
-    """Practice mode: record answer, show immediate feedback.
+    """Practice mode: record answer and show immediate feedback.
 
     6 outputs: state, question_html, radio, btn_submit, btn_next, btn_summary
     """
     if not state.get("quiz") or choice is None:
         return state, gr.update(), gr.update(), gr.update(), gr.update(), gr.update()
 
+    # Create a fresh state dict to avoid Gradio identity-check skipping the update
+    state = {**state}
     _record_answer(state, choice)
     state["submitted"] = True
 
@@ -295,78 +362,76 @@ def on_submit(state: dict, choice: str | None) -> tuple:
     )
 
 
-def on_next(state: dict, choice: str | None) -> tuple:
-    """Advance to the next question.
-
-    Practice: ignores choice (already recorded by on_submit), resets submit flow.
-    Exam: records choice silently, shows next question; auto-finishes on last.
-    """
-    is_exam = state.get("mode") == "exam"
-
-    if is_exam:
-        _record_answer(state, choice)
-
-    state["idx"] += 1
-    state["submitted"] = False
-
-    is_done = state["idx"] >= _total(state)
-
-    # Exam: auto-finish when all questions answered
-    if is_exam and is_done:
-        state["start_time"] = None  # stop timer
-        return (
-            state,
-            gr.update(value="", visible=False),
-            gr.update(choices=[], visible=False),
-            gr.update(visible=False),  # btn_submit
-            gr.update(visible=False),  # btn_next
-            gr.update(visible=False),  # btn_finish
-            gr.update(visible=False),  # btn_summary
-            gr.update(value=_debrief_html(state), visible=True),
-            gr.update(value="", visible=False),  # hide timer
-            gr.update(visible=True),  # btn_restart
-        )
-
+def on_next(state: dict) -> tuple:
+    """Practice mode: advance to the next question after feedback."""
+    # Fresh dict so Gradio always detects the state change
+    state = {**state, "idx": state["idx"] + 1, "submitted": False}
     return (
         state,
         _question_html(state),
-        gr.update(choices=_choices(state), value=None, interactive=True),
-        gr.update(visible=not is_exam),  # btn_submit: practice only
-        gr.update(visible=is_exam),  # btn_next: always in exam
-        gr.update(visible=is_exam),  # btn_finish: always in exam
+        gr.update(choices=_choices_for(state), value=None, interactive=True),
+        gr.update(visible=True),  # btn_submit
+        gr.update(visible=False),  # btn_prev
+        gr.update(visible=False),  # btn_next (hidden until next submit)
+        gr.update(visible=False),  # btn_finish
         gr.update(visible=False),  # btn_summary
         gr.update(value="", visible=False),  # summary_html
-        gr.update(),  # timer: leave as-is (still ticking)
+        gr.update(visible=False),  # timer_display
         gr.update(visible=False),  # btn_restart
     )
 
 
-def on_finish(state: dict, choice: str | None) -> tuple:
-    """Exam mode: record current answer (if any) and show full debrief."""
-    _record_answer(state, choice)
-    state["start_time"] = None  # stop timer
-    return (
-        state,
-        gr.update(value="", visible=False),
-        gr.update(choices=[], visible=False),
-        gr.update(visible=False),  # btn_submit
-        gr.update(visible=False),  # btn_next
-        gr.update(visible=False),  # btn_finish
-        gr.update(visible=False),  # btn_summary
-        gr.update(value=_debrief_html(state), visible=True),
-        gr.update(value="", visible=False),  # hide timer
-        gr.update(visible=True),  # btn_restart
-    )
+def on_prev_exam(state: dict) -> tuple:
+    """Exam mode: go to the previous question."""
+    if state["idx"] == 0:
+        return _exam_nav(state)
+    state = {**state, "idx": state["idx"] - 1}
+    return _exam_nav(state)
+
+
+def on_next_exam(state: dict) -> tuple:
+    """Exam mode: go to the next question."""
+    total = _total(state)
+    if state["idx"] >= total - 1:
+        return _exam_nav(state)
+    state = {**state, "idx": state["idx"] + 1}
+    return _exam_nav(state)
+
+
+def on_finish_exam(state: dict) -> tuple:
+    """Exam mode: submit all answers and show debrief."""
+    return _debrief_outputs(state)
 
 
 def on_show_results(state: dict) -> tuple:
-    """Practice mode: show debrief after the last question (2 outputs)."""
+    """Practice mode: show debrief after the last question. 2 outputs."""
     return gr.update(value=_debrief_html(state), visible=True), gr.update(visible=True)
 
 
 def on_restart(state: dict, mode: str) -> tuple:
-    """Restart the current quiz from scratch with the same mode."""
+    """Restart the current quiz from scratch."""
     return on_load_quiz(state.get("quiz_name", ""), mode)
+
+
+def on_timer_tick(state: dict) -> tuple:
+    """Update countdown every second; auto-submit when time is up.
+
+    11 outputs matching _ALL so the debrief can be shown directly from
+    the timer without any extra user interaction.
+    """
+    if state.get("mode") != "exam" or state.get("start_time") is None:
+        # No active exam — emit no-ops for everything except timer_display
+        return (gr.update(),) * 9 + (gr.update(visible=False),) + (gr.update(),)
+
+    elapsed = time.time() - state["start_time"]
+    remaining = state["limit_seconds"] - elapsed
+
+    if remaining <= 0:
+        return _debrief_outputs(state)
+
+    # Normal tick: only update the timer display
+    noop = gr.update()
+    return (noop,) * 9 + (gr.update(value=_fmt_time(remaining), visible=True),) + (noop,)
 
 
 # ---------------------------------------------------------------------------
@@ -388,8 +453,7 @@ def build_ui() -> gr.Blocks:
             label="Mode",
             info=(
                 "Practice: submit each answer to see immediate feedback. "
-                "Exam: answer all questions within the time limit, "
-                "then receive a full debrief."
+                "Exam: navigate freely, submit when ready (timer auto-submits on expiry)."
             ),
         )
 
@@ -403,19 +467,21 @@ def build_ui() -> gr.Blocks:
 
         with gr.Row():
             btn_submit = gr.Button("Submit", variant="primary", visible=False)
+            btn_prev = gr.Button("← Prev", visible=False)
             btn_next = gr.Button("Next →", visible=False)
-            btn_finish = gr.Button("⏹ Finish Exam", variant="stop", visible=False)
+            btn_finish = gr.Button("Submit Exam", variant="stop", visible=False)
             btn_summary = gr.Button("Show Results", variant="secondary", visible=False)
 
         summary_html = gr.HTML(visible=False)
         btn_restart = gr.Button("🔄 Restart Quiz", variant="secondary", visible=False)
 
-        # Full 10-output list shared by load / next / finish / restart
-        _all = [
+        # 11-output contract shared by load / exam nav / finish / restart / timer
+        _ALL = [
             state,
             question_html,
             radio,
             btn_submit,
+            btn_prev,
             btn_next,
             btn_finish,
             btn_summary,
@@ -424,36 +490,31 @@ def build_ui() -> gr.Blocks:
             btn_restart,
         ]
 
-        btn_load.click(on_load_quiz, inputs=[quiz_dropdown, mode_radio], outputs=_all)
-        quiz_dropdown.change(on_load_quiz, inputs=[quiz_dropdown, mode_radio], outputs=_all)
+        # --- Load ---
+        btn_load.click(on_load_quiz, inputs=[quiz_dropdown, mode_radio], outputs=_ALL)
+        quiz_dropdown.change(on_load_quiz, inputs=[quiz_dropdown, mode_radio], outputs=_ALL)
 
-        # Countdown ticker — fires every second, updates display + deactivates on 00:00
-        gr.Timer(value=1).tick(
-            on_timer_tick,
-            inputs=[state],
-            outputs=[timer_display, state],
-        )
+        # --- Exam mode: auto-save answer on selection ---
+        radio.change(on_radio_change, inputs=[state, radio], outputs=[state])
 
-        # Practice: Submit → feedback; Next → advance
+        # --- Practice mode ---
         btn_submit.click(
             on_submit,
             inputs=[state, radio],
             outputs=[state, question_html, radio, btn_submit, btn_next, btn_summary],
         )
-        btn_next.click(on_next, inputs=[state, radio], outputs=_all)
+        btn_next.click(on_next, inputs=[state], outputs=_ALL)
+        btn_summary.click(on_show_results, inputs=[state], outputs=[summary_html, btn_restart])
 
-        # Exam: Finish records last answer and shows debrief
-        btn_finish.click(on_finish, inputs=[state, radio], outputs=_all)
+        # --- Exam mode ---
+        btn_prev.click(on_prev_exam, inputs=[state], outputs=_ALL)
+        btn_finish.click(on_finish_exam, inputs=[state], outputs=_ALL)
 
-        # Practice: Show Results after last question (2 outputs)
-        btn_summary.click(
-            on_show_results,
-            inputs=[state],
-            outputs=[summary_html, btn_restart],
-        )
+        # --- Countdown (fires every second; auto-submits when time's up) ---
+        gr.Timer(value=1).tick(on_timer_tick, inputs=[state], outputs=_ALL)
 
-        # Restart: reload same quiz + mode from scratch
-        btn_restart.click(on_restart, inputs=[state, mode_radio], outputs=_all)
+        # --- Restart ---
+        btn_restart.click(on_restart, inputs=[state, mode_radio], outputs=_ALL)
 
     return demo
 

--- a/app.py
+++ b/app.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import html as _html
 import json
+import time
 from pathlib import Path
 
 import gradio as gr
@@ -50,10 +51,13 @@ def _load_quiz(name: str) -> dict | None:
 def _initial_state() -> dict:
     return {
         "quiz": None,
+        "quiz_name": "",  # stored for restart
         "idx": 0,
         "answers": [],  # 1-based chosen index per question, None = unanswered
         "submitted": False,  # whether current question was submitted (practice only)
         "mode": "practice",  # "practice" | "exam"
+        "start_time": None,  # time.time() when exam started, None when inactive
+        "limit_seconds": 0,  # exam time limit in seconds
     }
 
 
@@ -182,55 +186,23 @@ def _debrief_html(state: dict) -> str:
     return "\n".join(lines)
 
 
-def _timer_html(minutes: int) -> str:
-    """Client-side countdown timer.  Uses a generation counter so reloading
-    the quiz cancels any previous interval without needing server round-trips."""
-    seconds = minutes * 60
-    return f"""
-<div style="font-size:1.4em;font-weight:bold;color:#c0392b;margin-bottom:0.5em">
-  ⏱ <span id="quiz-timer-display">--:--</span>
-</div>
-<script>
-(function() {{
-  window._quizTimerGen = (window._quizTimerGen || 0) + 1;
-  var myGen = window._quizTimerGen;
-  var remaining = {seconds};
-  var el = null;
-  function tick() {{
-    if (window._quizTimerGen !== myGen) return;
-    if (!el) el = document.getElementById('quiz-timer-display');
-    if (!el) {{ setTimeout(tick, 200); return; }}
-    var m = Math.floor(remaining / 60);
-    var s = remaining % 60;
-    el.textContent = (m < 10 ? '0' : '') + m + ':' + (s < 10 ? '0' : '') + s;
-    if (remaining > 0) {{
-      remaining--;
-      setTimeout(tick, 1000);
-    }} else {{
-      el.textContent = "00:00 \u2014 Time\u2019s up!";
-      el.parentElement.style.color = '#e74c3c';
-    }}
-  }}
-  tick();
-}})();
-</script>
-"""
+def _fmt_time(seconds: float) -> str:
+    seconds = max(0, int(seconds))
+    return f"⏱ {seconds // 60:02d}:{seconds % 60:02d}"
 
 
 # ---------------------------------------------------------------------------
 # Event handlers
 #
-# Output contract (9 values, used by load + next + finish):
+# Full output contract (10 values):
 #   state, question_html, radio,
 #   btn_submit, btn_next, btn_finish, btn_summary,
-#   summary_html, timer_html
+#   summary_html, timer_display, btn_restart
 # ---------------------------------------------------------------------------
-
-_N = 9  # number of full-view outputs
 
 
 def _blank() -> tuple:
-    """Return a fully-reset 9-output tuple (no quiz loaded)."""
+    """Return a fully-reset 10-output tuple (no quiz loaded)."""
     return (
         _initial_state(),
         _no_quiz_html(),
@@ -240,7 +212,8 @@ def _blank() -> tuple:
         gr.update(visible=False),  # btn_finish
         gr.update(visible=False),  # btn_summary
         gr.update(value="", visible=False),  # summary_html
-        gr.update(value="", visible=False),  # timer_html
+        gr.update(value="", visible=False),  # timer_display
+        gr.update(visible=False),  # btn_restart
     )
 
 
@@ -254,11 +227,17 @@ def on_load_quiz(name: str, mode: str) -> tuple:
 
     state = _initial_state()
     state["quiz"] = quiz
+    state["quiz_name"] = name
     state["mode"] = mode.lower()
     state["answers"] = [None] * len(quiz.get("questions", []))
 
     is_exam = state["mode"] == "exam"
     exam_info = quiz.get("exam_info", {})
+    limit_seconds = exam_info.get("time_limit_minutes", 30) * 60
+
+    if is_exam:
+        state["start_time"] = time.time()
+        state["limit_seconds"] = limit_seconds
 
     return (
         state,
@@ -269,18 +248,34 @@ def on_load_quiz(name: str, mode: str) -> tuple:
         gr.update(visible=is_exam),  # btn_finish: exam only
         gr.update(visible=False),  # btn_summary
         gr.update(value="", visible=False),  # summary_html
-        gr.update(
-            value=_timer_html(exam_info.get("time_limit_minutes", 30)),
-            visible=is_exam,
-        ),
+        gr.update(value=_fmt_time(limit_seconds), visible=is_exam),  # timer: show start time
+        gr.update(visible=False),  # btn_restart
     )
+
+
+def on_timer_tick(state: dict) -> tuple:
+    """Update the countdown display every second (exam mode only).
+
+    Returns (timer_display update, state).  State is returned so the
+    timer can mark itself inactive when time runs out.
+    """
+    if state.get("mode") != "exam" or state.get("start_time") is None:
+        return gr.update(), state
+
+    elapsed = time.time() - state["start_time"]
+    remaining = state["limit_seconds"] - elapsed
+
+    if remaining <= 0:
+        state = {**state, "start_time": None}  # deactivate
+        return gr.update(value="⏱ 00:00 — Time's up!", visible=True), state
+
+    return gr.update(value=_fmt_time(remaining), visible=True), state
 
 
 def on_submit(state: dict, choice: str | None) -> tuple:
     """Practice mode: record answer, show immediate feedback.
 
     6 outputs: state, question_html, radio, btn_submit, btn_next, btn_summary
-    (timer and btn_finish are exam-only and untouched here)
     """
     if not state.get("quiz") or choice is None:
         return state, gr.update(), gr.update(), gr.update(), gr.update(), gr.update()
@@ -318,16 +313,18 @@ def on_next(state: dict, choice: str | None) -> tuple:
 
     # Exam: auto-finish when all questions answered
     if is_exam and is_done:
+        state["start_time"] = None  # stop timer
         return (
             state,
-            gr.update(value="", visible=False),  # hide question
-            gr.update(choices=[], visible=False),  # hide radio
+            gr.update(value="", visible=False),
+            gr.update(choices=[], visible=False),
             gr.update(visible=False),  # btn_submit
             gr.update(visible=False),  # btn_next
             gr.update(visible=False),  # btn_finish
             gr.update(visible=False),  # btn_summary
             gr.update(value=_debrief_html(state), visible=True),
             gr.update(value="", visible=False),  # hide timer
+            gr.update(visible=True),  # btn_restart
         )
 
     return (
@@ -339,13 +336,15 @@ def on_next(state: dict, choice: str | None) -> tuple:
         gr.update(visible=is_exam),  # btn_finish: always in exam
         gr.update(visible=False),  # btn_summary
         gr.update(value="", visible=False),  # summary_html
-        gr.update(),  # timer: leave as-is
+        gr.update(),  # timer: leave as-is (still ticking)
+        gr.update(visible=False),  # btn_restart
     )
 
 
 def on_finish(state: dict, choice: str | None) -> tuple:
     """Exam mode: record current answer (if any) and show full debrief."""
     _record_answer(state, choice)
+    state["start_time"] = None  # stop timer
     return (
         state,
         gr.update(value="", visible=False),
@@ -356,12 +355,18 @@ def on_finish(state: dict, choice: str | None) -> tuple:
         gr.update(visible=False),  # btn_summary
         gr.update(value=_debrief_html(state), visible=True),
         gr.update(value="", visible=False),  # hide timer
+        gr.update(visible=True),  # btn_restart
     )
 
 
-def on_show_results(state: dict) -> gr.update:
-    """Practice mode: show debrief after the last question."""
-    return gr.update(value=_debrief_html(state), visible=True)
+def on_show_results(state: dict) -> tuple:
+    """Practice mode: show debrief after the last question (2 outputs)."""
+    return gr.update(value=_debrief_html(state), visible=True), gr.update(visible=True)
+
+
+def on_restart(state: dict, mode: str) -> tuple:
+    """Restart the current quiz from scratch with the same mode."""
+    return on_load_quiz(state.get("quiz_name", ""), mode)
 
 
 # ---------------------------------------------------------------------------
@@ -392,7 +397,7 @@ def build_ui() -> gr.Blocks:
             quiz_dropdown = gr.Dropdown(choices=available, label="Select quiz", scale=3)
             btn_load = gr.Button("▶ Load", variant="primary", scale=1)
 
-        timer_html = gr.HTML(visible=False)
+        timer_display = gr.Markdown(value="", visible=False)
         question_html = gr.HTML(_no_quiz_html())
         radio = gr.Radio(choices=[], label="Your answer", interactive=True)
 
@@ -403,8 +408,9 @@ def build_ui() -> gr.Blocks:
             btn_summary = gr.Button("Show Results", variant="secondary", visible=False)
 
         summary_html = gr.HTML(visible=False)
+        btn_restart = gr.Button("🔄 Restart Quiz", variant="secondary", visible=False)
 
-        # Full 9-output list shared by load / next / finish
+        # Full 10-output list shared by load / next / finish / restart
         _all = [
             state,
             question_html,
@@ -414,11 +420,19 @@ def build_ui() -> gr.Blocks:
             btn_finish,
             btn_summary,
             summary_html,
-            timer_html,
+            timer_display,
+            btn_restart,
         ]
 
         btn_load.click(on_load_quiz, inputs=[quiz_dropdown, mode_radio], outputs=_all)
         quiz_dropdown.change(on_load_quiz, inputs=[quiz_dropdown, mode_radio], outputs=_all)
+
+        # Countdown ticker — fires every second, updates display + deactivates on 00:00
+        gr.Timer(value=1).tick(
+            on_timer_tick,
+            inputs=[state],
+            outputs=[timer_display, state],
+        )
 
         # Practice: Submit → feedback; Next → advance
         btn_submit.click(
@@ -431,8 +445,15 @@ def build_ui() -> gr.Blocks:
         # Exam: Finish records last answer and shows debrief
         btn_finish.click(on_finish, inputs=[state, radio], outputs=_all)
 
-        # Practice: Show Results after last question
-        btn_summary.click(on_show_results, inputs=[state], outputs=[summary_html])
+        # Practice: Show Results after last question (2 outputs)
+        btn_summary.click(
+            on_show_results,
+            inputs=[state],
+            outputs=[summary_html, btn_restart],
+        )
+
+        # Restart: reload same quiz + mode from scratch
+        btn_restart.click(on_restart, inputs=[state, mode_radio], outputs=_all)
 
     return demo
 

--- a/app.py
+++ b/app.py
@@ -2,8 +2,9 @@
 
 Two modes
 ---------
-Practice  — answer each question and get immediate feedback + rationale before moving on.
-Exam      — navigate freely between questions, submit when ready (or when time runs out).
+Practice  — select an answer and get immediate feedback + rationale; move on with Next.
+Exam      — navigate freely with Prev/Next; Submit appears once all questions answered;
+            timer auto-submits on expiry.
 
 Launch with:
     uv run --group app python app.py
@@ -51,12 +52,11 @@ def _load_quiz(name: str) -> dict | None:
 def _initial_state() -> dict:
     return {
         "quiz": None,
-        "quiz_name": "",  # stored for restart
+        "quiz_name": "",
         "idx": 0,
-        "answers": [],  # 1-based chosen index per question, None = unanswered
-        "submitted": False,  # True after on_submit in practice (locks radio)
+        "answers": [],  # 1-based answer index per question, None = unanswered
         "mode": "practice",  # "practice" | "exam"
-        "start_time": None,  # time.time() when exam started; None = inactive
+        "start_time": None,  # Unix timestamp when exam started; None = inactive
         "limit_seconds": 0,
     }
 
@@ -86,8 +86,11 @@ def _score(state: dict) -> int:
     )
 
 
+def _all_answered(state: dict) -> bool:
+    return bool(state.get("answers")) and all(a is not None for a in state["answers"])
+
+
 def _record_answer(state: dict, choice: str | None) -> None:
-    """Store the 1-based answer index for the current question."""
     if choice is None or not state.get("quiz"):
         return
     letter = choice.split(")")[0].strip() if ")" in choice else choice
@@ -98,53 +101,45 @@ def _record_answer(state: dict, choice: str | None) -> None:
 
 
 def _stored_choice(state: dict) -> str | None:
-    """Return the radio choice string for the already-recorded answer, or None."""
+    """Return the radio choice string for the stored answer at current idx."""
     idx = state["idx"]
     answers = state.get("answers", [])
     if idx >= len(answers) or answers[idx] is None:
         return None
-    ans = answers[idx]  # 1-based
+    ans = answers[idx]
     choices = _choices_for(state)
     return choices[ans - 1] if 1 <= ans <= len(choices) else None
 
 
 # ---------------------------------------------------------------------------
-# HTML rendering (all LLM-generated text is escaped)
+# HTML rendering (all LLM-generated text escaped)
 # ---------------------------------------------------------------------------
-
-
-def _no_quiz_html() -> str:
-    return "<p style='color:grey'>Select a quiz and click <strong>▶ Load</strong> to begin.</p>"
 
 
 def _question_html(state: dict, with_feedback: bool = False) -> str:
     q = _current_q(state)
     if q is None:
-        return _no_quiz_html()
+        return "<p style='color:grey'>No question loaded.</p>"
     idx = state["idx"]
     total = _total(state)
     section = _html.escape(q.get("section", ""))
     text = _html.escape(q.get("question", ""))
     section_tag = (
-        f"<span style='color:#7f8c8d;font-size:0.85em'>{section}</span><br>" if section else ""
+        f"<p style='color:#7f8c8d;font-size:0.85em;margin:0'>{section}</p>" if section else ""
     )
-    out = (
-        f"{section_tag}"
-        f"<strong>Q{idx + 1} / {total}</strong><br>"
-        f"<p style='font-size:1.1em'>{text}</p>"
-    )
+    out = f"{section_tag}<h3 style='margin:0.3em 0'>Q{idx + 1} / {total}</h3><p>{text}</p>"
+
     if with_feedback:
         ans = state["answers"][idx] if idx < len(state["answers"]) else None
         correct = q["correct_answer"]
         is_correct = ans == correct
         correct_letter = _LETTER[correct - 1]
-        verdict = (
-            "✅ Correct!" if is_correct else f"❌ Incorrect — correct answer: {correct_letter})"
-        )
+        wrong = f"<span style='color:#c0392b'>❌ Incorrect — correct: {correct_letter})</span>"
+        verdict = "<span style='color:#27ae60'>✅ Correct!</span>" if is_correct else wrong
         rationale = _html.escape(q.get("explanation", ""))
         out += f"<div style='margin-top:0.8em'><strong>{verdict}</strong>"
         if rationale:
-            out += f"<p><em>Rationale:</em> {rationale}</p>"
+            out += f"<p style='margin-top:0.4em'><em>Explanation:</em> {rationale}</p>"
         out += "</div>"
     return out
 
@@ -156,7 +151,7 @@ def _choices_for(state: dict) -> list[str]:
     return [f"{_LETTER[i]}) {opt}" for i, opt in enumerate(q.get("options", []))]
 
 
-def _debrief_html(state: dict) -> str:
+def _report_html(state: dict) -> str:
     quiz = state.get("quiz")
     if not quiz:
         return ""
@@ -170,10 +165,9 @@ def _debrief_html(state: dict) -> str:
     color = "#27ae60" if passed else "#c0392b"
 
     lines = [
-        f"<h2 style='color:{color}'>{badge}</h2>",
-        f"<p><strong>Score:</strong> {score}/{total} ({pct}%)</p>",
-        f"<p><strong>Passing threshold:</strong> {passing}%</p>",
-        "<hr><h3>Question Review</h3><ol>",
+        f"<h2 style='color:{color}'>{badge} — {pct}%</h2>",
+        f"<p><strong>Score:</strong> {score} / {total} correct (passing: {passing}%)</p>",
+        "<hr><h3>Review</h3><ol style='padding-left:1.2em'>",
     ]
     for i, q in enumerate(quiz["questions"]):
         user_ans = state["answers"][i] if i < len(state["answers"]) else None
@@ -184,14 +178,15 @@ def _debrief_html(state: dict) -> str:
         ok = "✅" if user_ans == correct else "❌"
         correct_text = _html.escape(options[correct - 1]) if 0 < correct <= len(options) else ""
         explanation = _html.escape(q.get("explanation", ""))
-        snippet = _html.escape(q["question"][:100])
+        snippet = _html.escape(q["question"])
+        lines.append("<li style='margin-bottom:1em'>")
+        lines.append(f"<strong>{ok} {snippet}</strong><br>")
         lines.append(
-            f"<li style='margin-bottom:0.8em'>{ok} <em>{snippet}…</em><br>"
-            f"Your answer: <strong>{user_letter}</strong> | "
-            f"Correct: <strong>{correct_letter}) {correct_text}</strong>"
+            f"Your answer: <em>{user_letter}</em> &nbsp;|&nbsp; "
+            f"Correct: <em>{correct_letter}) {correct_text}</em>"
         )
         if explanation:
-            lines.append(f"<br><small><em>Rationale: {explanation}</em></small>")
+            lines.append(f"<br><span style='color:#555;font-size:0.9em'>💡 {explanation}</span>")
         lines.append("</li>")
     lines.append("</ol>")
     return "\n".join(lines)
@@ -199,76 +194,66 @@ def _debrief_html(state: dict) -> str:
 
 def _fmt_time(seconds: float) -> str:
     s = max(0, int(seconds))
-    return f"⏱ {s // 60:02d}:{s % 60:02d}"
+    return f"## ⏱ {s // 60:02d}:{s % 60:02d}"
 
 
 # ---------------------------------------------------------------------------
-# Output helpers
-#
-# Full contract — 11 outputs (_ALL):
+# Output contract — 9 components
 #   state, question_html, radio,
-#   btn_submit, btn_prev, btn_next, btn_finish, btn_summary,
-#   summary_html, timer_display, btn_restart
+#   btn_prev, btn_next, btn_submit_exam,
+#   report_html, timer_md, btn_restart
 # ---------------------------------------------------------------------------
 
 
-def _blank() -> tuple:
-    """Fully-reset 11-output tuple for when no quiz is loaded."""
+def _blank_outputs() -> tuple:
     return (
         _initial_state(),
-        _no_quiz_html(),
-        gr.update(choices=[], value=None),
-        gr.update(visible=False),  # btn_submit
+        gr.update(value="", visible=False),  # question_html
+        gr.update(choices=[], value=None, visible=False),  # radio
         gr.update(visible=False),  # btn_prev
         gr.update(visible=False),  # btn_next
-        gr.update(visible=False),  # btn_finish
-        gr.update(visible=False),  # btn_summary
-        gr.update(value="", visible=False),  # summary_html
-        gr.update(value="", visible=False),  # timer_display
+        gr.update(visible=False),  # btn_submit_exam
+        gr.update(value="", visible=False),  # report_html
+        gr.update(value="", visible=False),  # timer_md
         gr.update(visible=False),  # btn_restart
     )
 
 
-def _exam_nav(state: dict) -> tuple:
-    """Return the 11-output tuple for a normal exam question view."""
-    idx = state["idx"]
-    total = _total(state)
-    at_first = idx == 0
-    at_last = idx >= total - 1
-    return (
-        state,
-        _question_html(state),
-        gr.update(
-            choices=_choices_for(state),
-            value=_stored_choice(state),  # restore previously selected answer
-            interactive=True,
-        ),
-        gr.update(visible=False),  # btn_submit
-        gr.update(visible=not at_first),  # btn_prev
-        gr.update(visible=not at_last),  # btn_next
-        gr.update(visible=True),  # btn_finish (always)
-        gr.update(visible=False),  # btn_summary
-        gr.update(value="", visible=False),  # summary_html
-        gr.update(),  # timer_display: keep as-is
-        gr.update(visible=False),  # btn_restart
-    )
-
-
-def _debrief_outputs(state: dict) -> tuple:
-    """Return the 11-output tuple showing the debrief panel."""
-    state = {**state, "start_time": None}  # stop timer
+def _report_outputs(state: dict) -> tuple:
+    """Transition to the final report screen."""
+    state = {**state, "start_time": None}
     return (
         state,
         gr.update(value="", visible=False),
-        gr.update(choices=[], visible=False),
-        gr.update(visible=False),  # btn_submit
+        gr.update(choices=[], value=None, visible=False),
         gr.update(visible=False),  # btn_prev
         gr.update(visible=False),  # btn_next
-        gr.update(visible=False),  # btn_finish
-        gr.update(visible=False),  # btn_summary
-        gr.update(value=_debrief_html(state), visible=True),
+        gr.update(visible=False),  # btn_submit_exam
+        gr.update(value=_report_html(state), visible=True),
         gr.update(value="", visible=False),  # hide timer
         gr.update(visible=True),  # btn_restart
+    )
+
+
+def _exam_question_outputs(state: dict) -> tuple:
+    """Render the current exam question with correct nav-button states."""
+    idx = state["idx"]
+    total = _total(state)
+    return (
+        state,
+        gr.update(value=_question_html(state), visible=True),
+        gr.update(
+            choices=_choices_for(state),
+            value=_stored_choice(state),
+            interactive=True,
+            visible=True,
+        ),
+        gr.update(visible=idx > 0),  # btn_prev: disabled at Q1
+        gr.update(visible=idx < total - 1),  # btn_next: disabled at last Q
+        gr.update(visible=_all_answered(state)),  # btn_submit_exam
+        gr.update(value="", visible=False),  # report
+        gr.update(),  # timer: leave as-is
+        gr.update(visible=False),  # btn_restart
     )
 
 
@@ -277,12 +262,13 @@ def _debrief_outputs(state: dict) -> tuple:
 # ---------------------------------------------------------------------------
 
 
-def on_load_quiz(name: str, mode: str) -> tuple:
+def on_start(name: str, mode: str) -> tuple:
+    """Start button: load quiz and show first question."""
     if not name:
-        return _blank()
+        return _blank_outputs()
     quiz = _load_quiz(name)
     if quiz is None:
-        return _blank()
+        return _blank_outputs()
 
     state = _initial_state()
     state["quiz"] = quiz
@@ -297,141 +283,139 @@ def on_load_quiz(name: str, mode: str) -> tuple:
     if is_exam:
         state["start_time"] = time.time()
         state["limit_seconds"] = limit_seconds
-        # Exam: show first question with nav buttons + timer
-        total = _total(state)
         return (
             state,
-            _question_html(state),
-            gr.update(choices=_choices_for(state), value=None, interactive=True),
-            gr.update(visible=False),  # btn_submit
+            gr.update(value=_question_html(state), visible=True),
+            gr.update(choices=_choices_for(state), value=None, interactive=True, visible=True),
             gr.update(visible=False),  # btn_prev (at Q1)
-            gr.update(visible=total > 1),  # btn_next
-            gr.update(visible=True),  # btn_finish
-            gr.update(visible=False),  # btn_summary
-            gr.update(value="", visible=False),  # summary_html
+            gr.update(visible=_total(state) > 1),  # btn_next
+            gr.update(visible=False),  # btn_submit_exam (not all answered yet)
+            gr.update(value="", visible=False),  # report
             gr.update(value=_fmt_time(limit_seconds), visible=True),
             gr.update(visible=False),  # btn_restart
         )
     else:
-        # Practice: show first question with Submit
+        # Practice: show first question; radio.change handles feedback
         return (
             state,
-            _question_html(state),
-            gr.update(choices=_choices_for(state), value=None, interactive=True),
-            gr.update(visible=True),  # btn_submit
+            gr.update(value=_question_html(state), visible=True),
+            gr.update(choices=_choices_for(state), value=None, interactive=True, visible=True),
             gr.update(visible=False),  # btn_prev
-            gr.update(visible=False),  # btn_next (appears after submit)
-            gr.update(visible=False),  # btn_finish
-            gr.update(visible=False),  # btn_summary
-            gr.update(value="", visible=False),  # summary_html
-            gr.update(value="", visible=False),  # no timer
-            gr.update(visible=False),  # btn_restart
+            gr.update(visible=False),  # btn_next (appears after answering)
+            gr.update(visible=False),  # btn_submit_exam
+            gr.update(value="", visible=False),
+            gr.update(value="", visible=False),
+            gr.update(visible=False),
         )
 
 
-def on_radio_change(state: dict, choice: str | None) -> dict:
-    """Exam mode only: auto-save answer on radio selection (no server round-trip needed
-    for practice — Submit handles that)."""
-    if state.get("mode") == "exam":
-        _record_answer(state, choice)
-    return state
+def on_answer(state: dict, choice: str | None) -> tuple:
+    """Fires whenever the radio value changes.
 
-
-def on_submit(state: dict, choice: str | None) -> tuple:
-    """Practice mode: record answer and show immediate feedback.
-
-    6 outputs: state, question_html, radio, btn_submit, btn_next, btn_summary
+    Practice: show immediate feedback, lock radio, reveal Next.
+    Exam:     save answer, update Submit Exam visibility.
     """
-    if not state.get("quiz") or choice is None:
-        return state, gr.update(), gr.update(), gr.update(), gr.update(), gr.update()
+    # Guard: ignore programmatic resets (value→None when loading next question)
+    if choice is None or not state.get("quiz"):
+        return (state,) + (gr.update(),) * 8
 
-    # Create a fresh state dict to avoid Gradio identity-check skipping the update
-    state = {**state}
-    _record_answer(state, choice)
-    state["submitted"] = True
+    mode = state.get("mode", "practice")
+    state = {**state}  # fresh dict to ensure Gradio detects state change
 
-    idx = state["idx"]
-    is_last = idx >= _total(state) - 1
-    return (
-        state,
-        _question_html(state, with_feedback=True),
-        gr.update(interactive=False),  # lock radio
-        gr.update(visible=False),  # hide Submit
-        gr.update(visible=not is_last),  # Next → next question
-        gr.update(visible=is_last),  # Show Results on last
-    )
+    if mode == "practice":
+        _record_answer(state, choice)
+        idx = state["idx"]
+        is_last = idx >= _total(state) - 1
+        return (
+            state,
+            gr.update(value=_question_html(state, with_feedback=True), visible=True),
+            gr.update(interactive=False),  # lock radio
+            gr.update(visible=False),  # btn_prev
+            gr.update(visible=True, value="Next →" if not is_last else "See Results →"),
+            gr.update(visible=False),  # btn_submit_exam
+            gr.update(value="", visible=False),
+            gr.update(),  # timer: no-op
+            gr.update(visible=False),
+        )
+    else:  # exam
+        _record_answer(state, choice)
+        return (
+            state,
+            gr.update(),  # question_html: no-op
+            gr.update(),  # radio: keep selection
+            gr.update(),  # btn_prev: no-op
+            gr.update(),  # btn_next: no-op
+            gr.update(visible=_all_answered(state)),  # reveal Submit when done
+            gr.update(value="", visible=False),
+            gr.update(),
+            gr.update(visible=False),
+        )
 
 
 def on_next(state: dict) -> tuple:
-    """Practice mode: advance to the next question after feedback."""
-    # Fresh dict so Gradio always detects the state change
-    state = {**state, "idx": state["idx"] + 1, "submitted": False}
+    """Practice mode: advance after feedback (or show report on last question)."""
+    new_idx = state["idx"] + 1
+    state = {**state, "idx": new_idx}
+
+    if new_idx >= _total(state):
+        return _report_outputs(state)
+
     return (
         state,
-        _question_html(state),
-        gr.update(choices=_choices_for(state), value=None, interactive=True),
-        gr.update(visible=True),  # btn_submit
+        gr.update(value=_question_html(state), visible=True),
+        gr.update(choices=_choices_for(state), value=None, interactive=True, visible=True),
         gr.update(visible=False),  # btn_prev
-        gr.update(visible=False),  # btn_next (hidden until next submit)
-        gr.update(visible=False),  # btn_finish
-        gr.update(visible=False),  # btn_summary
-        gr.update(value="", visible=False),  # summary_html
-        gr.update(visible=False),  # timer_display
-        gr.update(visible=False),  # btn_restart
+        gr.update(visible=False),  # btn_next (hidden until next answer)
+        gr.update(visible=False),  # btn_submit_exam
+        gr.update(value="", visible=False),
+        gr.update(visible=False),
+        gr.update(visible=False),
     )
 
 
 def on_prev_exam(state: dict) -> tuple:
-    """Exam mode: go to the previous question."""
     if state["idx"] == 0:
-        return _exam_nav(state)
+        return _exam_question_outputs(state)
     state = {**state, "idx": state["idx"] - 1}
-    return _exam_nav(state)
+    return _exam_question_outputs(state)
 
 
 def on_next_exam(state: dict) -> tuple:
-    """Exam mode: go to the next question."""
     total = _total(state)
     if state["idx"] >= total - 1:
-        return _exam_nav(state)
+        return _exam_question_outputs(state)
     state = {**state, "idx": state["idx"] + 1}
-    return _exam_nav(state)
+    return _exam_question_outputs(state)
 
 
-def on_finish_exam(state: dict) -> tuple:
-    """Exam mode: submit all answers and show debrief."""
-    return _debrief_outputs(state)
-
-
-def on_show_results(state: dict) -> tuple:
-    """Practice mode: show debrief after the last question. 2 outputs."""
-    return gr.update(value=_debrief_html(state), visible=True), gr.update(visible=True)
+def on_submit_exam(state: dict) -> tuple:
+    return _report_outputs(state)
 
 
 def on_restart(state: dict, mode: str) -> tuple:
-    """Restart the current quiz from scratch."""
-    return on_load_quiz(state.get("quiz_name", ""), mode)
+    return on_start(state.get("quiz_name", ""), mode)
 
 
 def on_timer_tick(state: dict) -> tuple:
-    """Update countdown every second; auto-submit when time is up.
-
-    11 outputs matching _ALL so the debrief can be shown directly from
-    the timer without any extra user interaction.
-    """
+    """Server-side countdown tick; auto-submits when time expires."""
     if state.get("mode") != "exam" or state.get("start_time") is None:
-        # No active exam — emit no-ops for everything except timer_display
-        return (gr.update(),) * 9 + (gr.update(visible=False),) + (gr.update(),)
+        return (state,) + (gr.update(),) * 8
 
-    elapsed = time.time() - state["start_time"]
-    remaining = state["limit_seconds"] - elapsed
-
+    remaining = state["limit_seconds"] - (time.time() - state["start_time"])
     if remaining <= 0:
-        return _debrief_outputs(state)
+        return _report_outputs(state)
 
-    # Normal tick: only update the timer display
-    noop = gr.update()
-    return (noop,) * 9 + (gr.update(value=_fmt_time(remaining), visible=True),) + (noop,)
+    return (
+        state,
+        gr.update(),
+        gr.update(),
+        gr.update(),
+        gr.update(),
+        gr.update(),
+        gr.update(),
+        gr.update(value=_fmt_time(remaining), visible=True),
+        gr.update(),
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -443,7 +427,7 @@ def build_ui() -> gr.Blocks:
     available = _list_quizzes()
 
     with gr.Blocks(title="NanoClaw Quiz") as demo:
-        gr.Markdown("# NanoClaw Interactive Quiz")
+        gr.Markdown("# NanoClaw Quiz")
 
         state = gr.State(_initial_state())
 
@@ -452,68 +436,54 @@ def build_ui() -> gr.Blocks:
             value="Practice",
             label="Mode",
             info=(
-                "Practice: submit each answer to see immediate feedback. "
-                "Exam: navigate freely, submit when ready (timer auto-submits on expiry)."
+                "Practice: select an answer to see immediate feedback. "
+                "Exam: navigate freely, submit when ready (timer auto-submits)."
             ),
         )
 
-        with gr.Row():
-            quiz_dropdown = gr.Dropdown(choices=available, label="Select quiz", scale=3)
-            btn_load = gr.Button("▶ Load", variant="primary", scale=1)
+        quiz_dropdown = gr.Dropdown(choices=available, label="Select quiz")
+        btn_start = gr.Button("▶ Start", variant="primary")
 
-        timer_display = gr.Markdown(value="", visible=False)
-        question_html = gr.HTML(_no_quiz_html())
-        radio = gr.Radio(choices=[], label="Your answer", interactive=True)
+        timer_md = gr.Markdown(value="", visible=False)
+        question_html = gr.HTML(visible=False)
+        radio = gr.Radio(choices=[], label="", interactive=True, visible=False)
 
         with gr.Row():
-            btn_submit = gr.Button("Submit", variant="primary", visible=False)
             btn_prev = gr.Button("← Prev", visible=False)
             btn_next = gr.Button("Next →", visible=False)
-            btn_finish = gr.Button("Submit Exam", variant="stop", visible=False)
-            btn_summary = gr.Button("Show Results", variant="secondary", visible=False)
+            btn_submit_exam = gr.Button("Submit Exam", variant="stop", visible=False)
 
-        summary_html = gr.HTML(visible=False)
-        btn_restart = gr.Button("🔄 Restart Quiz", variant="secondary", visible=False)
+        report_html = gr.HTML(visible=False)
+        btn_restart = gr.Button("🔄 Restart", variant="secondary", visible=False)
 
-        # 11-output contract shared by load / exam nav / finish / restart / timer
+        # 9-output list used by most handlers
         _ALL = [
             state,
             question_html,
             radio,
-            btn_submit,
             btn_prev,
             btn_next,
-            btn_finish,
-            btn_summary,
-            summary_html,
-            timer_display,
+            btn_submit_exam,
+            report_html,
+            timer_md,
             btn_restart,
         ]
 
-        # --- Load ---
-        btn_load.click(on_load_quiz, inputs=[quiz_dropdown, mode_radio], outputs=_ALL)
-        quiz_dropdown.change(on_load_quiz, inputs=[quiz_dropdown, mode_radio], outputs=_ALL)
+        btn_start.click(on_start, inputs=[quiz_dropdown, mode_radio], outputs=_ALL)
 
-        # --- Exam mode: auto-save answer on selection ---
-        radio.change(on_radio_change, inputs=[state, radio], outputs=[state])
+        # Practice: immediate feedback on selection; exam: auto-save + Submit visibility
+        radio.change(on_answer, inputs=[state, radio], outputs=_ALL)
 
-        # --- Practice mode ---
-        btn_submit.click(
-            on_submit,
-            inputs=[state, radio],
-            outputs=[state, question_html, radio, btn_submit, btn_next, btn_summary],
-        )
+        # Practice navigation
         btn_next.click(on_next, inputs=[state], outputs=_ALL)
-        btn_summary.click(on_show_results, inputs=[state], outputs=[summary_html, btn_restart])
 
-        # --- Exam mode ---
+        # Exam navigation
         btn_prev.click(on_prev_exam, inputs=[state], outputs=_ALL)
-        btn_finish.click(on_finish_exam, inputs=[state], outputs=_ALL)
+        btn_submit_exam.click(on_submit_exam, inputs=[state], outputs=_ALL)
 
-        # --- Countdown (fires every second; auto-submits when time's up) ---
+        # Countdown — fires every second
         gr.Timer(value=1).tick(on_timer_tick, inputs=[state], outputs=_ALL)
 
-        # --- Restart ---
         btn_restart.click(on_restart, inputs=[state, mode_radio], outputs=_ALL)
 
     return demo

--- a/app.py
+++ b/app.py
@@ -9,6 +9,7 @@ in outputs/quizzes/*.gradio.json.
 
 from __future__ import annotations
 
+import html
 import json
 from pathlib import Path
 
@@ -52,7 +53,7 @@ def _initial_state() -> dict:
     return {
         "quiz": None,  # full Gradio JSON dict
         "idx": 0,  # current question index (0-based)
-        "answers": [],  # user's answer indices (1-based, None if skipped)
+        "answers": [],  # user's answer indices (1-based, None if not answered)
         "submitted": False,  # whether current question has been submitted
     }
 
@@ -88,21 +89,23 @@ def _score(state: dict) -> int:
 # ---------------------------------------------------------------------------
 
 
-_HIDDEN = (gr.update(visible=False),) * 3
-
-
 def on_load_quiz(name: str) -> tuple:
-    """Load a quiz by name and return initial UI state."""
+    """Load a quiz by name and return initial UI state (7 outputs)."""
+    blank = (
+        _initial_state(),
+        _no_quiz_html(),
+        gr.update(choices=[], value=None),
+        gr.update(visible=False),  # btn_submit
+        gr.update(visible=False),  # btn_next
+        gr.update(visible=False),  # btn_summary
+        gr.update(value="", visible=False),  # summary_html
+    )
     if not name:
-        return (_initial_state(), _no_quiz_html(), gr.update(choices=[], value=None)) + _HIDDEN
+        return blank
 
     quiz = _load_quiz(name)
     if quiz is None:
-        return (
-            _initial_state(),
-            "<p>Quiz file not found.</p>",
-            gr.update(choices=[], value=None),
-        ) + _HIDDEN
+        return blank
 
     state = _initial_state()
     state["quiz"] = quiz
@@ -112,17 +115,25 @@ def on_load_quiz(name: str) -> tuple:
     return (
         state,
         question_html,
-        gr.update(choices=choices, value=None),
+        gr.update(choices=choices, value=None, interactive=True),
         submit_vis,
         next_vis,
         summary_vis,
+        gr.update(value="", visible=False),  # reset summary panel
     )
 
 
 def on_submit(state: dict, choice: str | None) -> tuple:
-    """Record the user's answer and reveal rationale."""
+    """Record the user's answer and reveal rationale (6 outputs)."""
     if state.get("quiz") is None or choice is None:
-        return state, gr.update(), gr.update(), gr.update(), gr.update()
+        return (
+            state,
+            gr.update(),
+            gr.update(),
+            gr.update(),
+            gr.update(),
+            gr.update(),
+        )
 
     # Parse chosen letter back to 1-based index
     letter = choice.split(")")[0].strip() if ")" in choice else choice
@@ -137,13 +148,14 @@ def on_submit(state: dict, choice: str | None) -> tuple:
     is_correct = chosen_idx == correct
     explanation = question.get("explanation", "")
 
-    # Build feedback HTML
+    # Build feedback HTML — escape LLM-generated text before embedding
     correct_letter = _LETTER[correct - 1]
     verdict = "✅ Correct!" if is_correct else f"❌ Incorrect. Correct answer: {correct_letter})"
-    feedback_html = f"<div style='margin-top:1em'><strong>{verdict}</strong>"
+    feedback_parts = [f"<div style='margin-top:1em'><strong>{verdict}</strong>"]
     if explanation:
-        feedback_html += f"<p><em>Rationale:</em> {explanation}</p>"
-    feedback_html += "</div>"
+        feedback_parts.append(f"<p><em>Rationale:</em> {html.escape(explanation)}</p>")
+    feedback_parts.append("</div>")
+    feedback_html = "".join(feedback_parts)
 
     question_html, choices, _, _, _ = _render_question(state)
     full_html = question_html + feedback_html
@@ -157,12 +169,12 @@ def on_submit(state: dict, choice: str | None) -> tuple:
         gr.update(choices=choices, interactive=False),  # lock radio
         gr.update(visible=False),  # hide Submit
         gr.update(visible=not is_last),  # Next (not on last)
-        gr.update(visible=is_last),  # Show summary on last
+        gr.update(visible=is_last),  # Show summary button on last
     )
 
 
 def on_next(state: dict) -> tuple:
-    """Advance to the next question."""
+    """Advance to the next question (7 outputs)."""
     state["idx"] += 1
     state["submitted"] = False
     question_html, choices, submit_vis, next_vis, summary_vis = _render_question(state)
@@ -173,14 +185,15 @@ def on_next(state: dict) -> tuple:
         submit_vis,
         next_vis,
         summary_vis,
+        gr.update(visible=False),  # keep summary panel hidden between questions
     )
 
 
-def on_summary(state: dict) -> str:
-    """Build the final score summary HTML."""
+def on_summary(state: dict) -> gr.update:
+    """Build the final score summary and make the panel visible."""
     quiz = state.get("quiz")
     if not quiz:
-        return ""
+        return gr.update(value="", visible=False)
     exam = quiz.get("exam_info", {})
     total = _total(state)
     score = _score(state)
@@ -203,13 +216,14 @@ def on_summary(state: dict) -> str:
         user_letter = _LETTER[user_ans - 1] if user_ans and 1 <= user_ans <= 4 else "–"
         correct_letter = _LETTER[correct - 1]
         ok = "✅" if user_ans == correct else "❌"
-        correct_text = options[correct - 1] if 0 < correct <= len(options) else ""
+        correct_text = html.escape(options[correct - 1]) if 0 < correct <= len(options) else ""
+        question_snippet = html.escape(q["question"][:80])
         lines.append(
-            f"<li>{ok} <em>{q['question'][:80]}…</em><br>"
+            f"<li>{ok} <em>{question_snippet}…</em><br>"
             f"Your answer: {user_letter} | Correct: {correct_letter}) {correct_text}</li>"
         )
     lines.append("</ol>")
-    return "\n".join(lines)
+    return gr.update(value="\n".join(lines), visible=True)
 
 
 # ---------------------------------------------------------------------------
@@ -218,36 +232,43 @@ def on_summary(state: dict) -> str:
 
 
 def _no_quiz_html() -> str:
-    return "<p style='color:grey'>Select a quiz from the dropdown to begin.</p>"
+    return "<p style='color:grey'>Select a quiz and click <strong>Load</strong> to begin.</p>"
 
 
 def _render_question(state: dict) -> tuple:
     """Return (question_html, radio_choices, submit_vis, next_vis, summary_vis)."""
     question = _current_question(state)
     if question is None:
-        return (_no_quiz_html(), []) + _HIDDEN
+        return (
+            _no_quiz_html(),
+            [],
+            gr.update(visible=False),
+            gr.update(visible=False),
+            gr.update(visible=False),
+        )
 
     idx = state["idx"]
     total = _total(state)
     options = question.get("options", [])
     choices = [f"{_LETTER[i]}) {opt}" for i, opt in enumerate(options)]
 
-    section = question.get("section", "")
+    section = html.escape(question.get("section", ""))
     section_tag = (
         f"<span style='color:grey;font-size:0.85em'>{section}</span><br>" if section else ""
     )
-    html = (
+    question_text = html.escape(question.get("question", ""))
+    question_html = (
         f"{section_tag}"
         f"<strong>Q{idx + 1} / {total}</strong><br>"
-        f"<p style='font-size:1.1em'>{question['question']}</p>"
+        f"<p style='font-size:1.1em'>{question_text}</p>"
     )
     submitted = state.get("submitted", False)
     return (
-        html,
+        question_html,
         choices,
         gr.update(visible=not submitted),  # Submit
         gr.update(visible=False),  # Next (shown after submit by on_submit)
-        gr.update(visible=False),  # Summary
+        gr.update(visible=False),  # Summary button
     )
 
 
@@ -270,6 +291,7 @@ def build_ui() -> gr.Blocks:
                 label="Select quiz",
                 scale=3,
             )
+            btn_load = gr.Button("▶ Load", variant="primary", scale=1)
 
         question_html = gr.HTML(_no_quiz_html())
         radio = gr.Radio(choices=[], label="Your answer", interactive=True)
@@ -281,11 +303,28 @@ def build_ui() -> gr.Blocks:
 
         summary_html = gr.HTML(visible=False)
 
-        # Wire events
+        # Shared output list for events that reset the full quiz view (7 outputs)
+        _quiz_view_outputs = [
+            state,
+            question_html,
+            radio,
+            btn_submit,
+            btn_next,
+            btn_summary,
+            summary_html,
+        ]
+
+        btn_load.click(
+            on_load_quiz,
+            inputs=[quiz_dropdown],
+            outputs=_quiz_view_outputs,
+        )
+
+        # Also trigger on dropdown change for keyboard/programmatic use
         quiz_dropdown.change(
             on_load_quiz,
             inputs=[quiz_dropdown],
-            outputs=[state, question_html, radio, btn_submit, btn_next, btn_summary],
+            outputs=_quiz_view_outputs,
         )
 
         btn_submit.click(
@@ -297,13 +336,13 @@ def build_ui() -> gr.Blocks:
         btn_next.click(
             on_next,
             inputs=[state],
-            outputs=[state, question_html, radio, btn_submit, btn_next, btn_summary],
+            outputs=_quiz_view_outputs,
         )
 
         btn_summary.click(
-            lambda s: (on_summary(s), gr.update(visible=True)),
+            on_summary,
             inputs=[state],
-            outputs=[summary_html, summary_html],
+            outputs=[summary_html],
         )
 
     return demo

--- a/app.py
+++ b/app.py
@@ -1,0 +1,313 @@
+"""Gradio interactive quiz app.
+
+Launch with:
+    uv run --group app python app.py
+
+Or deploy to HuggingFace Spaces by pointing at pre-generated Gradio JSON files
+in outputs/quizzes/*.gradio.json.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import gradio as gr
+
+from src.common.config import get_settings, project_root
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_LETTER = "ABCD"
+
+
+def _quizzes_dir() -> Path:
+    cfg = get_settings()
+    return project_root() / cfg.quiz.quizzes_dir
+
+
+def _list_quizzes() -> list[str]:
+    """Return display names (stems) of available Gradio quiz JSON files."""
+    d = _quizzes_dir()
+    if not d.exists():
+        return []
+    return sorted(p.stem.replace(".gradio", "") for p in d.glob("*.gradio.json"))
+
+
+def _load_quiz(name: str) -> dict | None:
+    path = _quizzes_dir() / f"{name}.gradio.json"
+    if not path.exists():
+        return None
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+# ---------------------------------------------------------------------------
+# State helpers — pure functions operating on the session state dict
+# ---------------------------------------------------------------------------
+
+
+def _initial_state() -> dict:
+    return {
+        "quiz": None,  # full Gradio JSON dict
+        "idx": 0,  # current question index (0-based)
+        "answers": [],  # user's answer indices (1-based, None if skipped)
+        "submitted": False,  # whether current question has been submitted
+    }
+
+
+def _current_question(state: dict) -> dict | None:
+    q = state.get("quiz")
+    if q is None:
+        return None
+    questions = q.get("questions", [])
+    idx = state.get("idx", 0)
+    return questions[idx] if idx < len(questions) else None
+
+
+def _total(state: dict) -> int:
+    q = state.get("quiz")
+    return len(q.get("questions", [])) if q else 0
+
+
+def _score(state: dict) -> int:
+    q = state.get("quiz")
+    if not q:
+        return 0
+    correct = 0
+    for i, ans in enumerate(state["answers"]):
+        questions = q["questions"]
+        if i < len(questions) and ans == questions[i]["correct_answer"]:
+            correct += 1
+    return correct
+
+
+# ---------------------------------------------------------------------------
+# Event handlers
+# ---------------------------------------------------------------------------
+
+
+_HIDDEN = (gr.update(visible=False),) * 3
+
+
+def on_load_quiz(name: str) -> tuple:
+    """Load a quiz by name and return initial UI state."""
+    if not name:
+        return (_initial_state(), _no_quiz_html(), gr.update(choices=[], value=None)) + _HIDDEN
+
+    quiz = _load_quiz(name)
+    if quiz is None:
+        return (
+            _initial_state(),
+            "<p>Quiz file not found.</p>",
+            gr.update(choices=[], value=None),
+        ) + _HIDDEN
+
+    state = _initial_state()
+    state["quiz"] = quiz
+    state["answers"] = [None] * len(quiz.get("questions", []))
+
+    question_html, choices, submit_vis, next_vis, summary_vis = _render_question(state)
+    return (
+        state,
+        question_html,
+        gr.update(choices=choices, value=None),
+        submit_vis,
+        next_vis,
+        summary_vis,
+    )
+
+
+def on_submit(state: dict, choice: str | None) -> tuple:
+    """Record the user's answer and reveal rationale."""
+    if state.get("quiz") is None or choice is None:
+        return state, gr.update(), gr.update(), gr.update(), gr.update()
+
+    # Parse chosen letter back to 1-based index
+    letter = choice.split(")")[0].strip() if ")" in choice else choice
+    chosen_idx = _LETTER.index(letter) + 1 if letter in _LETTER else None
+
+    idx = state["idx"]
+    state["answers"][idx] = chosen_idx
+    state["submitted"] = True
+
+    question = _current_question(state)
+    correct = question["correct_answer"]
+    is_correct = chosen_idx == correct
+    explanation = question.get("explanation", "")
+
+    # Build feedback HTML
+    correct_letter = _LETTER[correct - 1]
+    verdict = "✅ Correct!" if is_correct else f"❌ Incorrect. Correct answer: {correct_letter})"
+    feedback_html = f"<div style='margin-top:1em'><strong>{verdict}</strong>"
+    if explanation:
+        feedback_html += f"<p><em>Rationale:</em> {explanation}</p>"
+    feedback_html += "</div>"
+
+    question_html, choices, _, _, _ = _render_question(state)
+    full_html = question_html + feedback_html
+
+    total = _total(state)
+    is_last = idx >= total - 1
+
+    return (
+        state,
+        full_html,
+        gr.update(choices=choices, interactive=False),  # lock radio
+        gr.update(visible=False),  # hide Submit
+        gr.update(visible=not is_last),  # Next (not on last)
+        gr.update(visible=is_last),  # Show summary on last
+    )
+
+
+def on_next(state: dict) -> tuple:
+    """Advance to the next question."""
+    state["idx"] += 1
+    state["submitted"] = False
+    question_html, choices, submit_vis, next_vis, summary_vis = _render_question(state)
+    return (
+        state,
+        question_html,
+        gr.update(choices=choices, value=None, interactive=True),
+        submit_vis,
+        next_vis,
+        summary_vis,
+    )
+
+
+def on_summary(state: dict) -> str:
+    """Build the final score summary HTML."""
+    quiz = state.get("quiz")
+    if not quiz:
+        return ""
+    exam = quiz.get("exam_info", {})
+    total = _total(state)
+    score = _score(state)
+    passing = exam.get("passing_score", 70)
+    pct = round(score / total * 100) if total else 0
+    passed = pct >= passing
+    badge = "🎉 PASSED" if passed else "❌ FAILED"
+    color = "#2ecc71" if passed else "#e74c3c"
+
+    lines = [
+        f"<h2 style='color:{color}'>{badge}</h2>",
+        f"<p><strong>Score:</strong> {score}/{total} ({pct}%)</p>",
+        f"<p><strong>Passing threshold:</strong> {passing}%</p>",
+        "<hr><h3>Review</h3><ol>",
+    ]
+    for i, q in enumerate(quiz["questions"]):
+        user_ans = state["answers"][i]
+        correct = q["correct_answer"]
+        options = q.get("options", [])
+        user_letter = _LETTER[user_ans - 1] if user_ans and 1 <= user_ans <= 4 else "–"
+        correct_letter = _LETTER[correct - 1]
+        ok = "✅" if user_ans == correct else "❌"
+        correct_text = options[correct - 1] if 0 < correct <= len(options) else ""
+        lines.append(
+            f"<li>{ok} <em>{q['question'][:80]}…</em><br>"
+            f"Your answer: {user_letter} | Correct: {correct_letter}) {correct_text}</li>"
+        )
+    lines.append("</ol>")
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Rendering helpers
+# ---------------------------------------------------------------------------
+
+
+def _no_quiz_html() -> str:
+    return "<p style='color:grey'>Select a quiz from the dropdown to begin.</p>"
+
+
+def _render_question(state: dict) -> tuple:
+    """Return (question_html, radio_choices, submit_vis, next_vis, summary_vis)."""
+    question = _current_question(state)
+    if question is None:
+        return (_no_quiz_html(), []) + _HIDDEN
+
+    idx = state["idx"]
+    total = _total(state)
+    options = question.get("options", [])
+    choices = [f"{_LETTER[i]}) {opt}" for i, opt in enumerate(options)]
+
+    section = question.get("section", "")
+    section_tag = (
+        f"<span style='color:grey;font-size:0.85em'>{section}</span><br>" if section else ""
+    )
+    html = (
+        f"{section_tag}"
+        f"<strong>Q{idx + 1} / {total}</strong><br>"
+        f"<p style='font-size:1.1em'>{question['question']}</p>"
+    )
+    submitted = state.get("submitted", False)
+    return (
+        html,
+        choices,
+        gr.update(visible=not submitted),  # Submit
+        gr.update(visible=False),  # Next (shown after submit by on_submit)
+        gr.update(visible=False),  # Summary
+    )
+
+
+# ---------------------------------------------------------------------------
+# UI
+# ---------------------------------------------------------------------------
+
+
+def build_ui() -> gr.Blocks:
+    available = _list_quizzes()
+
+    with gr.Blocks(title="NanoClaw Quiz") as demo:
+        gr.Markdown("# NanoClaw Interactive Quiz")
+
+        state = gr.State(_initial_state())
+
+        with gr.Row():
+            quiz_dropdown = gr.Dropdown(
+                choices=available,
+                label="Select quiz",
+                scale=3,
+            )
+
+        question_html = gr.HTML(_no_quiz_html())
+        radio = gr.Radio(choices=[], label="Your answer", interactive=True)
+
+        with gr.Row():
+            btn_submit = gr.Button("Submit", variant="primary", visible=False)
+            btn_next = gr.Button("Next →", visible=False)
+            btn_summary = gr.Button("Show results", variant="secondary", visible=False)
+
+        summary_html = gr.HTML(visible=False)
+
+        # Wire events
+        quiz_dropdown.change(
+            on_load_quiz,
+            inputs=[quiz_dropdown],
+            outputs=[state, question_html, radio, btn_submit, btn_next, btn_summary],
+        )
+
+        btn_submit.click(
+            on_submit,
+            inputs=[state, radio],
+            outputs=[state, question_html, radio, btn_submit, btn_next, btn_summary],
+        )
+
+        btn_next.click(
+            on_next,
+            inputs=[state],
+            outputs=[state, question_html, radio, btn_submit, btn_next, btn_summary],
+        )
+
+        btn_summary.click(
+            lambda s: (on_summary(s), gr.update(visible=True)),
+            inputs=[state],
+            outputs=[summary_html, summary_html],
+        )
+
+    return demo
+
+
+if __name__ == "__main__":
+    build_ui().launch()

--- a/app.py
+++ b/app.py
@@ -1,15 +1,17 @@
 """Gradio interactive quiz app.
 
+Two modes
+---------
+Practice  — answer each question and get immediate feedback + rationale before moving on.
+Exam      — answer all questions within a time limit; full debrief with explanations at the end.
+
 Launch with:
     uv run --group app python app.py
-
-Or deploy to HuggingFace Spaces by pointing at pre-generated Gradio JSON files
-in outputs/quizzes/*.gradio.json.
 """
 
 from __future__ import annotations
 
-import html
+import html as _html
 import json
 from pathlib import Path
 
@@ -17,20 +19,18 @@ import gradio as gr
 
 from src.common.config import get_settings, project_root
 
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
 _LETTER = "ABCD"
+
+# ---------------------------------------------------------------------------
+# Path / data helpers
+# ---------------------------------------------------------------------------
 
 
 def _quizzes_dir() -> Path:
-    cfg = get_settings()
-    return project_root() / cfg.quiz.quizzes_dir
+    return project_root() / get_settings().quiz.quizzes_dir
 
 
 def _list_quizzes() -> list[str]:
-    """Return display names (stems) of available Gradio quiz JSON files."""
     d = _quizzes_dir()
     if not d.exists():
         return []
@@ -39,161 +39,112 @@ def _list_quizzes() -> list[str]:
 
 def _load_quiz(name: str) -> dict | None:
     path = _quizzes_dir() / f"{name}.gradio.json"
-    if not path.exists():
-        return None
-    return json.loads(path.read_text(encoding="utf-8"))
+    return json.loads(path.read_text(encoding="utf-8")) if path.exists() else None
 
 
 # ---------------------------------------------------------------------------
-# State helpers — pure functions operating on the session state dict
+# State
 # ---------------------------------------------------------------------------
 
 
 def _initial_state() -> dict:
     return {
-        "quiz": None,  # full Gradio JSON dict
-        "idx": 0,  # current question index (0-based)
-        "answers": [],  # user's answer indices (1-based, None if not answered)
-        "submitted": False,  # whether current question has been submitted
+        "quiz": None,
+        "idx": 0,
+        "answers": [],  # 1-based chosen index per question, None = unanswered
+        "submitted": False,  # whether current question was submitted (practice only)
+        "mode": "practice",  # "practice" | "exam"
     }
-
-
-def _current_question(state: dict) -> dict | None:
-    q = state.get("quiz")
-    if q is None:
-        return None
-    questions = q.get("questions", [])
-    idx = state.get("idx", 0)
-    return questions[idx] if idx < len(questions) else None
 
 
 def _total(state: dict) -> int:
     q = state.get("quiz")
-    return len(q.get("questions", [])) if q else 0
+    return len(q["questions"]) if q else 0
+
+
+def _current_q(state: dict) -> dict | None:
+    q = state.get("quiz")
+    if not q:
+        return None
+    qs = q["questions"]
+    idx = state["idx"]
+    return qs[idx] if idx < len(qs) else None
 
 
 def _score(state: dict) -> int:
     q = state.get("quiz")
     if not q:
         return 0
-    correct = 0
-    for i, ans in enumerate(state["answers"]):
-        questions = q["questions"]
-        if i < len(questions) and ans == questions[i]["correct_answer"]:
-            correct += 1
-    return correct
-
-
-# ---------------------------------------------------------------------------
-# Event handlers
-# ---------------------------------------------------------------------------
-
-
-def on_load_quiz(name: str) -> tuple:
-    """Load a quiz by name and return initial UI state (7 outputs)."""
-    blank = (
-        _initial_state(),
-        _no_quiz_html(),
-        gr.update(choices=[], value=None),
-        gr.update(visible=False),  # btn_submit
-        gr.update(visible=False),  # btn_next
-        gr.update(visible=False),  # btn_summary
-        gr.update(value="", visible=False),  # summary_html
-    )
-    if not name:
-        return blank
-
-    quiz = _load_quiz(name)
-    if quiz is None:
-        return blank
-
-    state = _initial_state()
-    state["quiz"] = quiz
-    state["answers"] = [None] * len(quiz.get("questions", []))
-
-    question_html, choices, submit_vis, next_vis, summary_vis = _render_question(state)
-    return (
-        state,
-        question_html,
-        gr.update(choices=choices, value=None, interactive=True),
-        submit_vis,
-        next_vis,
-        summary_vis,
-        gr.update(value="", visible=False),  # reset summary panel
+    return sum(
+        1
+        for i, ans in enumerate(state["answers"])
+        if i < len(q["questions"]) and ans == q["questions"][i]["correct_answer"]
     )
 
 
-def on_submit(state: dict, choice: str | None) -> tuple:
-    """Record the user's answer and reveal rationale (6 outputs)."""
-    if state.get("quiz") is None or choice is None:
-        return (
-            state,
-            gr.update(),
-            gr.update(),
-            gr.update(),
-            gr.update(),
-            gr.update(),
-        )
-
-    # Parse chosen letter back to 1-based index
+def _record_answer(state: dict, choice: str | None) -> None:
+    """Parse the radio choice string and store the 1-based index in state."""
+    if choice is None or not state.get("quiz"):
+        return
     letter = choice.split(")")[0].strip() if ")" in choice else choice
     chosen_idx = _LETTER.index(letter) + 1 if letter in _LETTER else None
-
     idx = state["idx"]
-    state["answers"][idx] = chosen_idx
-    state["submitted"] = True
+    if idx < len(state["answers"]):
+        state["answers"][idx] = chosen_idx
 
-    question = _current_question(state)
-    correct = question["correct_answer"]
-    is_correct = chosen_idx == correct
-    explanation = question.get("explanation", "")
 
-    # Build feedback HTML — escape LLM-generated text before embedding
-    correct_letter = _LETTER[correct - 1]
-    verdict = "✅ Correct!" if is_correct else f"❌ Incorrect. Correct answer: {correct_letter})"
-    feedback_parts = [f"<div style='margin-top:1em'><strong>{verdict}</strong>"]
-    if explanation:
-        feedback_parts.append(f"<p><em>Rationale:</em> {html.escape(explanation)}</p>")
-    feedback_parts.append("</div>")
-    feedback_html = "".join(feedback_parts)
+# ---------------------------------------------------------------------------
+# HTML rendering (all LLM-generated text is escaped)
+# ---------------------------------------------------------------------------
 
-    question_html, choices, _, _, _ = _render_question(state)
-    full_html = question_html + feedback_html
 
+def _no_quiz_html() -> str:
+    return "<p style='color:grey'>Select a quiz and click <strong>▶ Load</strong> to begin.</p>"
+
+
+def _question_html(state: dict, with_feedback: bool = False) -> str:
+    q = _current_q(state)
+    if q is None:
+        return _no_quiz_html()
+    idx = state["idx"]
     total = _total(state)
-    is_last = idx >= total - 1
-
-    return (
-        state,
-        full_html,
-        gr.update(choices=choices, interactive=False),  # lock radio
-        gr.update(visible=False),  # hide Submit
-        gr.update(visible=not is_last),  # Next (not on last)
-        gr.update(visible=is_last),  # Show summary button on last
+    section = _html.escape(q.get("section", ""))
+    text = _html.escape(q.get("question", ""))
+    section_tag = (
+        f"<span style='color:#7f8c8d;font-size:0.85em'>{section}</span><br>" if section else ""
     )
-
-
-def on_next(state: dict) -> tuple:
-    """Advance to the next question (7 outputs)."""
-    state["idx"] += 1
-    state["submitted"] = False
-    question_html, choices, submit_vis, next_vis, summary_vis = _render_question(state)
-    return (
-        state,
-        question_html,
-        gr.update(choices=choices, value=None, interactive=True),
-        submit_vis,
-        next_vis,
-        summary_vis,
-        gr.update(visible=False),  # keep summary panel hidden between questions
+    out = (
+        f"{section_tag}"
+        f"<strong>Q{idx + 1} / {total}</strong><br>"
+        f"<p style='font-size:1.1em'>{text}</p>"
     )
+    if with_feedback:
+        ans = state["answers"][idx] if idx < len(state["answers"]) else None
+        correct = q["correct_answer"]
+        is_correct = ans == correct
+        correct_letter = _LETTER[correct - 1]
+        verdict = (
+            "✅ Correct!" if is_correct else f"❌ Incorrect — correct answer: {correct_letter})"
+        )
+        rationale = _html.escape(q.get("explanation", ""))
+        out += f"<div style='margin-top:0.8em'><strong>{verdict}</strong>"
+        if rationale:
+            out += f"<p><em>Rationale:</em> {rationale}</p>"
+        out += "</div>"
+    return out
 
 
-def on_summary(state: dict) -> gr.update:
-    """Build the final score summary and make the panel visible."""
+def _choices(state: dict) -> list[str]:
+    q = _current_q(state)
+    if not q:
+        return []
+    return [f"{_LETTER[i]}) {opt}" for i, opt in enumerate(q.get("options", []))]
+
+
+def _debrief_html(state: dict) -> str:
     quiz = state.get("quiz")
     if not quiz:
-        return gr.update(value="", visible=False)
+        return ""
     exam = quiz.get("exam_info", {})
     total = _total(state)
     score = _score(state)
@@ -201,75 +152,216 @@ def on_summary(state: dict) -> gr.update:
     pct = round(score / total * 100) if total else 0
     passed = pct >= passing
     badge = "🎉 PASSED" if passed else "❌ FAILED"
-    color = "#2ecc71" if passed else "#e74c3c"
+    color = "#27ae60" if passed else "#c0392b"
 
     lines = [
         f"<h2 style='color:{color}'>{badge}</h2>",
         f"<p><strong>Score:</strong> {score}/{total} ({pct}%)</p>",
         f"<p><strong>Passing threshold:</strong> {passing}%</p>",
-        "<hr><h3>Review</h3><ol>",
+        "<hr><h3>Question Review</h3><ol>",
     ]
     for i, q in enumerate(quiz["questions"]):
-        user_ans = state["answers"][i]
+        user_ans = state["answers"][i] if i < len(state["answers"]) else None
         correct = q["correct_answer"]
         options = q.get("options", [])
         user_letter = _LETTER[user_ans - 1] if user_ans and 1 <= user_ans <= 4 else "–"
         correct_letter = _LETTER[correct - 1]
         ok = "✅" if user_ans == correct else "❌"
-        correct_text = html.escape(options[correct - 1]) if 0 < correct <= len(options) else ""
-        question_snippet = html.escape(q["question"][:80])
+        correct_text = _html.escape(options[correct - 1]) if 0 < correct <= len(options) else ""
+        explanation = _html.escape(q.get("explanation", ""))
+        snippet = _html.escape(q["question"][:100])
         lines.append(
-            f"<li>{ok} <em>{question_snippet}…</em><br>"
-            f"Your answer: {user_letter} | Correct: {correct_letter}) {correct_text}</li>"
+            f"<li style='margin-bottom:0.8em'>{ok} <em>{snippet}…</em><br>"
+            f"Your answer: <strong>{user_letter}</strong> | "
+            f"Correct: <strong>{correct_letter}) {correct_text}</strong>"
         )
+        if explanation:
+            lines.append(f"<br><small><em>Rationale: {explanation}</em></small>")
+        lines.append("</li>")
     lines.append("</ol>")
-    return gr.update(value="\n".join(lines), visible=True)
+    return "\n".join(lines)
+
+
+def _timer_html(minutes: int) -> str:
+    """Client-side countdown timer.  Uses a generation counter so reloading
+    the quiz cancels any previous interval without needing server round-trips."""
+    seconds = minutes * 60
+    return f"""
+<div style="font-size:1.4em;font-weight:bold;color:#c0392b;margin-bottom:0.5em">
+  ⏱ <span id="quiz-timer-display">--:--</span>
+</div>
+<script>
+(function() {{
+  window._quizTimerGen = (window._quizTimerGen || 0) + 1;
+  var myGen = window._quizTimerGen;
+  var remaining = {seconds};
+  var el = null;
+  function tick() {{
+    if (window._quizTimerGen !== myGen) return;
+    if (!el) el = document.getElementById('quiz-timer-display');
+    if (!el) {{ setTimeout(tick, 200); return; }}
+    var m = Math.floor(remaining / 60);
+    var s = remaining % 60;
+    el.textContent = (m < 10 ? '0' : '') + m + ':' + (s < 10 ? '0' : '') + s;
+    if (remaining > 0) {{
+      remaining--;
+      setTimeout(tick, 1000);
+    }} else {{
+      el.textContent = "00:00 \u2014 Time\u2019s up!";
+      el.parentElement.style.color = '#e74c3c';
+    }}
+  }}
+  tick();
+}})();
+</script>
+"""
 
 
 # ---------------------------------------------------------------------------
-# Rendering helpers
+# Event handlers
+#
+# Output contract (9 values, used by load + next + finish):
+#   state, question_html, radio,
+#   btn_submit, btn_next, btn_finish, btn_summary,
+#   summary_html, timer_html
 # ---------------------------------------------------------------------------
 
-
-def _no_quiz_html() -> str:
-    return "<p style='color:grey'>Select a quiz and click <strong>Load</strong> to begin.</p>"
+_N = 9  # number of full-view outputs
 
 
-def _render_question(state: dict) -> tuple:
-    """Return (question_html, radio_choices, submit_vis, next_vis, summary_vis)."""
-    question = _current_question(state)
-    if question is None:
-        return (
-            _no_quiz_html(),
-            [],
-            gr.update(visible=False),
-            gr.update(visible=False),
-            gr.update(visible=False),
-        )
+def _blank() -> tuple:
+    """Return a fully-reset 9-output tuple (no quiz loaded)."""
+    return (
+        _initial_state(),
+        _no_quiz_html(),
+        gr.update(choices=[], value=None),
+        gr.update(visible=False),  # btn_submit
+        gr.update(visible=False),  # btn_next
+        gr.update(visible=False),  # btn_finish
+        gr.update(visible=False),  # btn_summary
+        gr.update(value="", visible=False),  # summary_html
+        gr.update(value="", visible=False),  # timer_html
+    )
+
+
+def on_load_quiz(name: str, mode: str) -> tuple:
+    """Load a quiz and initialise the correct mode layout."""
+    if not name:
+        return _blank()
+    quiz = _load_quiz(name)
+    if quiz is None:
+        return _blank()
+
+    state = _initial_state()
+    state["quiz"] = quiz
+    state["mode"] = mode.lower()
+    state["answers"] = [None] * len(quiz.get("questions", []))
+
+    is_exam = state["mode"] == "exam"
+    exam_info = quiz.get("exam_info", {})
+
+    return (
+        state,
+        _question_html(state),
+        gr.update(choices=_choices(state), value=None, interactive=True),
+        gr.update(visible=not is_exam),  # btn_submit: practice only
+        gr.update(visible=is_exam),  # btn_next: exam immediately; practice after submit
+        gr.update(visible=is_exam),  # btn_finish: exam only
+        gr.update(visible=False),  # btn_summary
+        gr.update(value="", visible=False),  # summary_html
+        gr.update(
+            value=_timer_html(exam_info.get("time_limit_minutes", 30)),
+            visible=is_exam,
+        ),
+    )
+
+
+def on_submit(state: dict, choice: str | None) -> tuple:
+    """Practice mode: record answer, show immediate feedback.
+
+    6 outputs: state, question_html, radio, btn_submit, btn_next, btn_summary
+    (timer and btn_finish are exam-only and untouched here)
+    """
+    if not state.get("quiz") or choice is None:
+        return state, gr.update(), gr.update(), gr.update(), gr.update(), gr.update()
+
+    _record_answer(state, choice)
+    state["submitted"] = True
 
     idx = state["idx"]
-    total = _total(state)
-    options = question.get("options", [])
-    choices = [f"{_LETTER[i]}) {opt}" for i, opt in enumerate(options)]
-
-    section = html.escape(question.get("section", ""))
-    section_tag = (
-        f"<span style='color:grey;font-size:0.85em'>{section}</span><br>" if section else ""
-    )
-    question_text = html.escape(question.get("question", ""))
-    question_html = (
-        f"{section_tag}"
-        f"<strong>Q{idx + 1} / {total}</strong><br>"
-        f"<p style='font-size:1.1em'>{question_text}</p>"
-    )
-    submitted = state.get("submitted", False)
+    is_last = idx >= _total(state) - 1
     return (
-        question_html,
-        choices,
-        gr.update(visible=not submitted),  # Submit
-        gr.update(visible=False),  # Next (shown after submit by on_submit)
-        gr.update(visible=False),  # Summary button
+        state,
+        _question_html(state, with_feedback=True),
+        gr.update(interactive=False),  # lock radio
+        gr.update(visible=False),  # hide Submit
+        gr.update(visible=not is_last),  # Next → next question
+        gr.update(visible=is_last),  # Show Results on last
     )
+
+
+def on_next(state: dict, choice: str | None) -> tuple:
+    """Advance to the next question.
+
+    Practice: ignores choice (already recorded by on_submit), resets submit flow.
+    Exam: records choice silently, shows next question; auto-finishes on last.
+    """
+    is_exam = state.get("mode") == "exam"
+
+    if is_exam:
+        _record_answer(state, choice)
+
+    state["idx"] += 1
+    state["submitted"] = False
+
+    is_done = state["idx"] >= _total(state)
+
+    # Exam: auto-finish when all questions answered
+    if is_exam and is_done:
+        return (
+            state,
+            gr.update(value="", visible=False),  # hide question
+            gr.update(choices=[], visible=False),  # hide radio
+            gr.update(visible=False),  # btn_submit
+            gr.update(visible=False),  # btn_next
+            gr.update(visible=False),  # btn_finish
+            gr.update(visible=False),  # btn_summary
+            gr.update(value=_debrief_html(state), visible=True),
+            gr.update(value="", visible=False),  # hide timer
+        )
+
+    return (
+        state,
+        _question_html(state),
+        gr.update(choices=_choices(state), value=None, interactive=True),
+        gr.update(visible=not is_exam),  # btn_submit: practice only
+        gr.update(visible=is_exam),  # btn_next: always in exam
+        gr.update(visible=is_exam),  # btn_finish: always in exam
+        gr.update(visible=False),  # btn_summary
+        gr.update(value="", visible=False),  # summary_html
+        gr.update(),  # timer: leave as-is
+    )
+
+
+def on_finish(state: dict, choice: str | None) -> tuple:
+    """Exam mode: record current answer (if any) and show full debrief."""
+    _record_answer(state, choice)
+    return (
+        state,
+        gr.update(value="", visible=False),
+        gr.update(choices=[], visible=False),
+        gr.update(visible=False),  # btn_submit
+        gr.update(visible=False),  # btn_next
+        gr.update(visible=False),  # btn_finish
+        gr.update(visible=False),  # btn_summary
+        gr.update(value=_debrief_html(state), visible=True),
+        gr.update(value="", visible=False),  # hide timer
+    )
+
+
+def on_show_results(state: dict) -> gr.update:
+    """Practice mode: show debrief after the last question."""
+    return gr.update(value=_debrief_html(state), visible=True)
 
 
 # ---------------------------------------------------------------------------
@@ -285,65 +377,62 @@ def build_ui() -> gr.Blocks:
 
         state = gr.State(_initial_state())
 
+        mode_radio = gr.Radio(
+            choices=["Practice", "Exam"],
+            value="Practice",
+            label="Mode",
+            info=(
+                "Practice: submit each answer to see immediate feedback. "
+                "Exam: answer all questions within the time limit, "
+                "then receive a full debrief."
+            ),
+        )
+
         with gr.Row():
-            quiz_dropdown = gr.Dropdown(
-                choices=available,
-                label="Select quiz",
-                scale=3,
-            )
+            quiz_dropdown = gr.Dropdown(choices=available, label="Select quiz", scale=3)
             btn_load = gr.Button("▶ Load", variant="primary", scale=1)
 
+        timer_html = gr.HTML(visible=False)
         question_html = gr.HTML(_no_quiz_html())
         radio = gr.Radio(choices=[], label="Your answer", interactive=True)
 
         with gr.Row():
             btn_submit = gr.Button("Submit", variant="primary", visible=False)
             btn_next = gr.Button("Next →", visible=False)
-            btn_summary = gr.Button("Show results", variant="secondary", visible=False)
+            btn_finish = gr.Button("⏹ Finish Exam", variant="stop", visible=False)
+            btn_summary = gr.Button("Show Results", variant="secondary", visible=False)
 
         summary_html = gr.HTML(visible=False)
 
-        # Shared output list for events that reset the full quiz view (7 outputs)
-        _quiz_view_outputs = [
+        # Full 9-output list shared by load / next / finish
+        _all = [
             state,
             question_html,
             radio,
             btn_submit,
             btn_next,
+            btn_finish,
             btn_summary,
             summary_html,
+            timer_html,
         ]
 
-        btn_load.click(
-            on_load_quiz,
-            inputs=[quiz_dropdown],
-            outputs=_quiz_view_outputs,
-        )
+        btn_load.click(on_load_quiz, inputs=[quiz_dropdown, mode_radio], outputs=_all)
+        quiz_dropdown.change(on_load_quiz, inputs=[quiz_dropdown, mode_radio], outputs=_all)
 
-        # Also trigger on dropdown change for keyboard/programmatic use
-        quiz_dropdown.change(
-            on_load_quiz,
-            inputs=[quiz_dropdown],
-            outputs=_quiz_view_outputs,
-        )
-
+        # Practice: Submit → feedback; Next → advance
         btn_submit.click(
             on_submit,
             inputs=[state, radio],
             outputs=[state, question_html, radio, btn_submit, btn_next, btn_summary],
         )
+        btn_next.click(on_next, inputs=[state, radio], outputs=_all)
 
-        btn_next.click(
-            on_next,
-            inputs=[state],
-            outputs=_quiz_view_outputs,
-        )
+        # Exam: Finish records last answer and shows debrief
+        btn_finish.click(on_finish, inputs=[state, radio], outputs=_all)
 
-        btn_summary.click(
-            on_summary,
-            inputs=[state],
-            outputs=[summary_html],
-        )
+        # Practice: Show Results after last question
+        btn_summary.click(on_show_results, inputs=[state], outputs=[summary_html])
 
     return demo
 

--- a/nanoclaw/config/settings.yaml
+++ b/nanoclaw/config/settings.yaml
@@ -31,6 +31,12 @@ ingest:
   chunk_size: 512         # words (text.split()); ~2000 chars / ~500 tokens per chunk
   chunk_overlap: 64       # words
 
+exam_info:
+  title: "NVIDIA Certification Practice Questions"
+  certifications: ["NCP-AII", "NCP-AIO"]
+  time_limit_minutes: 30
+  passing_score: 70
+
 quiz:
   outputs_dir: "outputs"
   quizzes_dir: "outputs/quizzes"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,9 @@ dev = [
     "ruff>=0.15",
     "pre-commit>=3.7",
 ]
+app = [
+    "gradio>=4.0",
+]
 
 [tool.ruff]
 line-length = 100

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dev = [
     "pre-commit>=3.7",
 ]
 app = [
-    "gradio>=4.0",
+    "gradio>=4.44",  # 4.44+ required for gr.Timer (server-side polling for the countdown)
 ]
 
 [tool.ruff]

--- a/src/common/config.py
+++ b/src/common/config.py
@@ -49,6 +49,13 @@ class IngestConfig(BaseModel):
     chunk_overlap: int = 64
 
 
+class ExamInfoConfig(BaseModel):
+    title: str = "Practice Questions"
+    certifications: list[str] = Field(default_factory=list)
+    time_limit_minutes: int = 30
+    passing_score: int = 70
+
+
 class QuizConfig(BaseModel):
     outputs_dir: str = "outputs"
     quizzes_dir: str = "outputs/quizzes"
@@ -68,6 +75,7 @@ class Settings(BaseModel):
     qdrant: QdrantConfig = Field(default_factory=QdrantConfig)
     ingest: IngestConfig = Field(default_factory=IngestConfig)
     quiz: QuizConfig = Field(default_factory=QuizConfig)
+    exam_info: ExamInfoConfig = Field(default_factory=ExamInfoConfig)
 
 
 def _find_project_root() -> Path:

--- a/src/quiz/export.py
+++ b/src/quiz/export.py
@@ -1,12 +1,14 @@
-"""Export quiz to Markdown, JSON, and CSV formats."""
+"""Export quiz to Markdown, JSON, CSV, and Gradio formats."""
 
 from __future__ import annotations
 
 import argparse
 import csv
+import json
 import sys
+from datetime import date
 
-from src.common.config import get_settings, project_root
+from src.common.config import ExamInfoConfig, get_settings, project_root
 from src.common.models import Quiz
 from src.common.slug import make_slug
 
@@ -84,8 +86,52 @@ def to_csv_rows(quiz: Quiz) -> list[dict]:
     return rows
 
 
+def to_gradio(quiz: Quiz, exam_info_overrides: ExamInfoConfig | None = None) -> dict:
+    """Serialise *quiz* to the Gradio-compatible schema used by the HuggingFace Space.
+
+    Only MCQ items that have not been rejected are included.  ``correct_answer``
+    is 1-indexed (the Space convention) while ``answer_index`` is 0-indexed.
+
+    ``exam_info_overrides`` takes precedence over whatever is in settings.yaml;
+    pass ``None`` to use the project defaults.
+    """
+    cfg_exam = exam_info_overrides or get_settings().exam_info
+    accepted_mcq = [
+        i
+        for i in quiz.items
+        if i.question_type == "mcq"
+        and i.confidence_flag != "rejected"
+        and i.choices
+        and i.answer_index is not None
+    ]
+    questions = []
+    for n, item in enumerate(accepted_mcq, 1):
+        questions.append(
+            {
+                "id": n,
+                "section": quiz.topic,
+                "question": item.question,
+                "options": item.choices,
+                "correct_answer": item.answer_index + 1,  # 1-indexed
+                "explanation": item.rationale,
+            }
+        )
+    last_updated = date.today().strftime("%B %Y")
+    return {
+        "exam_info": {
+            "title": cfg_exam.title,
+            "certifications": cfg_exam.certifications,
+            "total_questions": len(questions),
+            "time_limit_minutes": cfg_exam.time_limit_minutes,
+            "passing_score": cfg_exam.passing_score,
+            "last_updated": last_updated,
+        },
+        "questions": questions,
+    }
+
+
 def main() -> None:
-    parser = argparse.ArgumentParser(description="Export quiz to MD/JSON/CSV.")
+    parser = argparse.ArgumentParser(description="Export quiz to MD/JSON/CSV/Gradio.")
     parser.add_argument("--topic", required=True)
     parser.add_argument("--formats", nargs="+", default=["md", "json", "csv"])
     args = parser.parse_args()
@@ -157,6 +203,12 @@ def main() -> None:
     if "json" in args.formats:
         # Already exists; optionally export a clean version without embeddings
         print(f"JSON: {quiz_path} (already written by generate/validate)")
+
+    if "gradio" in args.formats:
+        gradio_data = to_gradio(quiz)
+        out = quizzes_dir / f"{slug}.gradio.json"
+        out.write_text(json.dumps(gradio_data, indent=2, ensure_ascii=False), encoding="utf-8")
+        print(f"Gradio: {out}")
 
     # Write rationales (only accepted items, numbered to match the exported quiz)
     rationale_lines = []

--- a/src/quiz/export.py
+++ b/src/quiz/export.py
@@ -103,6 +103,7 @@ def to_gradio(quiz: Quiz, exam_info_overrides: ExamInfoConfig | None = None) -> 
         and i.confidence_flag != "rejected"
         and i.choices
         and i.answer_index is not None
+        and 0 <= i.answer_index < len(i.choices)
     ]
     questions = []
     for n, item in enumerate(accepted_mcq, 1):

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -1,0 +1,101 @@
+"""Unit tests for quiz export functions."""
+
+from __future__ import annotations
+
+from src.common.config import ExamInfoConfig
+from src.common.models import Quiz, QuizItem
+from src.quiz.export import to_gradio
+
+
+def _make_item(**kwargs) -> QuizItem:
+    defaults = dict(
+        question_type="mcq",
+        question="What is X?",
+        choices=["Alpha", "Beta", "Gamma", "Delta"],
+        answer_index=1,
+        rationale="Because Beta.",
+        supporting_chunk_ids=["c1"],
+        source_files=["f.pdf"],
+        confidence_flag="ok",
+        grounding_verdict="supported",
+    )
+    defaults.update(kwargs)
+    return QuizItem(**defaults)
+
+
+def _make_quiz(*items: QuizItem, topic: str = "GPU Monitoring") -> Quiz:
+    return Quiz(topic=topic, items=list(items))
+
+
+def test_to_gradio_field_mapping():
+    quiz = _make_quiz(_make_item())
+    result = to_gradio(quiz)
+
+    q = result["questions"][0]
+    assert q["options"] == ["Alpha", "Beta", "Gamma", "Delta"]
+    # answer_index=1 (0-based) → correct_answer=2 (1-based)
+    assert q["correct_answer"] == 2
+    assert q["explanation"] == "Because Beta."
+    assert q["section"] == "GPU Monitoring"
+
+
+def test_to_gradio_excludes_rejected():
+    accepted = _make_item(question="Q1", answer_index=0, confidence_flag="ok")
+    rejected = _make_item(question="Q2", answer_index=0, confidence_flag="rejected")
+    result = to_gradio(_make_quiz(accepted, rejected))
+
+    assert len(result["questions"]) == 1
+    assert result["questions"][0]["question"] == "Q1"
+
+
+def test_to_gradio_excludes_non_mcq():
+    mcq = _make_item(question_type="mcq", question="MCQ?", answer_index=0)
+    sa = QuizItem(
+        question_type="short_answer",
+        question="SA?",
+        answer="yes",
+        confidence_flag="ok",
+    )
+    result = to_gradio(_make_quiz(mcq, sa))
+
+    assert len(result["questions"]) == 1
+    assert result["questions"][0]["question"] == "MCQ?"
+
+
+def test_to_gradio_excludes_out_of_bounds_answer_index():
+    bad = _make_item(answer_index=10)  # out of bounds for 4-choice list
+    result = to_gradio(_make_quiz(bad))
+
+    assert result["questions"] == []
+
+
+def test_to_gradio_exam_info_from_overrides():
+    exam_cfg = ExamInfoConfig(
+        title="My Exam",
+        certifications=["CERT-X"],
+        time_limit_minutes=45,
+        passing_score=80,
+    )
+    quiz = _make_quiz(_make_item())
+    result = to_gradio(quiz, exam_info_overrides=exam_cfg)
+
+    info = result["exam_info"]
+    assert info["title"] == "My Exam"
+    assert info["certifications"] == ["CERT-X"]
+    assert info["time_limit_minutes"] == 45
+    assert info["passing_score"] == 80
+    assert info["total_questions"] == 1
+
+
+def test_to_gradio_ids_are_one_indexed():
+    items = [_make_item(question=f"Q{i}", answer_index=0) for i in range(3)]
+    result = to_gradio(_make_quiz(*items))
+
+    ids = [q["id"] for q in result["questions"]]
+    assert ids == [1, 2, 3]
+
+
+def test_to_gradio_empty_quiz():
+    result = to_gradio(_make_quiz())
+    assert result["questions"] == []
+    assert result["exam_info"]["total_questions"] == 0


### PR DESCRIPTION
## Summary

- **`src/quiz/export.py`**: adds `to_gradio(quiz, exam_info_overrides)` and `--formats gradio` CLI flag. Maps `choices → options`, `answer_index` (0-based) → `correct_answer` (1-based), `rationale → explanation`; wraps output in `exam_info` block matching the HuggingFace Space schema. Validates `0 <= answer_index < len(choices)` to exclude malformed items.
- **`src/common/config.py`**: adds `ExamInfoConfig` (title, certifications, time_limit_minutes, passing_score) wired into `Settings`.
- **`nanoclaw/config/settings.yaml`**: adds `exam_info` defaults for NVIDIA NCP-AII/NCP-AIO certs.
- **`pyproject.toml`**: adds `[dependency-groups] app` with `gradio>=4.0` (optional, not required for the pipeline).
- **`app.py`**: self-contained Gradio app — quiz picker dropdown + explicit "▶ Load" button, question-by-question flow with locked radio after submit, `html.escape()` on all LLM-generated content, rationale reveal, final score summary with pass/fail. Launch with `uv run --group app python app.py`.
- **`tests/test_export.py`**: 7 focused tests for `to_gradio()` (field mapping, rejected/non-mcq exclusion, out-of-bounds answer_index, exam_info overrides, 1-indexed IDs, empty quiz).

## Export CLI usage

```bash
uv run python -m src.quiz.export --topic "GPU Monitoring" --formats gradio
# produces outputs/quizzes/gpu_monitoring.gradio.json
```

## Test plan

- [ ] All 87 tests pass (`uv run pytest tests/ -q`)
- [ ] `ruff check` clean
- [ ] Export: `--formats gradio` produces valid schema
- [ ] App: `uv run --group app python app.py` launches, click "▶ Load" starts quiz, flow works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)